### PR TITLE
feat(@/components/Button.tsx): 공용 버튼 컴포넌트 생성 (#10)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,8 @@
     "react/no-unescaped-entities": ["off"],
     "react/self-closing-comp": ["off"],
     "react/function-component-definition": [2, { "namedComponents": ["arrow-function"] }],
+    "react/button-has-type": ["off"],
+    "react/require-default-props": 0,
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-unused-vars": ["warn"],
     "@typescript-eslint/explicit-function-return-type": ["off"],

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,82 @@
+import styled, { RuleSet, css } from "styled-components";
+
+const SIZES = {
+  sm: css`
+    padding: 1rem;
+    font-size: 1.4rem;
+    font-weight: var(--weight-regular);
+  `,
+  md: css`
+    padding: 1.2rem;
+    font-size: 1.6rem;
+    font-weight: var(--weight-semibold);
+  `,
+  lg: css`
+    padding: 1.6rem;
+    font-size: 1.8rem;
+    font-weight: var(--weight-extrabold);
+  `,
+};
+
+const VARIANTS = {
+  point: css`
+    color: var(--color-white);
+    background-color: var(--color-sub-500);
+    border: none;
+  `,
+  sub: css`
+    color: var(--color-sub-500);
+    background-color: var(--color-white);
+    border: 1px solid var(--color-sub-500);
+  `,
+  normal: css`
+    color: var(--color-black);
+    background-color: var(--color-white);
+    border: 1px solid var(--color-black);
+    &:hover {
+      background-color: var(--color-gray-50);
+    }
+  `,
+};
+
+interface ButtonProps {
+  value: string;
+  disabled?: boolean;
+  size: "sm" | "md" | "lg";
+  variant: "point" | "sub" | "normal";
+}
+
+interface CustomProperties {
+  $sizeStyle: RuleSet<object>;
+  $variantStyle: RuleSet<object>;
+}
+
+const Button = ({ value, disabled = false, size, variant }: ButtonProps) => {
+  const sizeStyle = SIZES[size];
+  const variantStyle = VARIANTS[variant];
+
+  return (
+    <ButtonContainer disabled={disabled} $sizeStyle={sizeStyle} $variantStyle={variantStyle}>
+      {value}
+    </ButtonContainer>
+  );
+};
+
+export default Button;
+
+const ButtonContainer = styled.button<CustomProperties>`
+  ${(props) => props.$sizeStyle}
+  ${(props) => props.$variantStyle}
+
+  width: 100%;
+  margin: 0;
+  border-radius: var(--radius-button);
+  cursor: pointer;
+  font-family: suit;
+  font-weight: var(--weight-extrabold);
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+`;

--- a/src/index.css
+++ b/src/index.css
@@ -1,2 +1,6 @@
 @import url(/src/styles/reset.css);
 @import url(/src/styles/global.css);
+
+html {
+  font-size: 62.5%;
+}


### PR DESCRIPTION
## 📤 반영 브랜치
`feat/common-button-component` -> `dev`

## 🔧 작업 내용
- 공용 버튼 컴포넌트 생성
- rem 사용을 위한 html 태그 font-size 62.5% 설정

## 📸 스크린샷
<img width="327" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/e3419f51-b6b5-40f5-af7f-a95e8ca7c154">

## 🔗 관련 이슈

#10 #11  

## 💬 참고사항
- width는 100%로 설정해두었기 때문에 부모의 width를 조절하면 됩니다.
- margin은 0으로 설정해두었기 때문에 부모 요소에서 조절하면 됩니다.
- disabled 여부는 옵셔널입니다. 전달하지 않는 경우 default 값은 false로 설정됩니다.
- onClick속성은 본 버튼을 감싸는 태그에 전달하면 됩니다.
- 버튼의 type은 submit이 기본이므로 따로 전달받지 않도록 설정했습니다.
  form 태그의 onSubmit에 함수를 전달하면 됩니다.
- Link태그를 사용하는 경우 본 버튼을 Link태그로 감싸면 작동합니다. 
Link태그의 width 값을 변경하려면 `display: block` 으로 설정해줘야 합니다.