### PR TITLE
feat(@/src/common, @/types): Input 컴포넌트 추가(#9)

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,48 @@
+import styled, { css, RuleSet } from "styled-components";
+import { InputProps } from "@/types/input";
+
+const Input = ({
+  type = "text",
+  placeholder = "",
+  onChange = () => {},
+  onFocus = () => {},
+  onBlur = () => {},
+  onKeyDown = () => {},
+  value,
+  disabled = false,
+  inputStyle = "normal",
+}: InputProps) => {
+  const currentStyle = INPUT_STYLES[inputStyle];
+  return (
+    <InputContainer
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      onChange={onChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      disabled={disabled}
+      $inputStyle={currentStyle}
+    ></InputContainer>
+  );
+};
+
+const INPUT_STYLES = Object.freeze({
+  normal: css`
+    &:focus {
+      outline: none;
+    }
+    border: 1px solid var(--color-gray-200);
+  `,
+});
+
+const InputContainer = styled.input<{ $inputStyle: RuleSet<object> }>`
+  ${(props) => props.$inputStyle}
+
+  border-radius: var(--radius-input);
+  border-style: solid;
+  border-width: 1px;
+`;
+
+export default Input;

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -1,0 +1,24 @@
+/**
+ * InputType : input태그의 type 형태 중 글자 입력 형태의 목록
+ */
+type InputType = "text" | "email" | "password" | "search" | "tel" | "url";
+
+/**
+ * inputStyle : 정의된 input 태그의 style 목록
+ */
+type InputStyle = "normal";
+
+/**
+ * Input 컴포넌트의 props
+ */
+export interface InputProps {
+  type?: InputType;
+  placeholder?: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  value: string;
+  disabled?: boolean;
+  inputStyle?: InputStyle;
+}


### PR DESCRIPTION
공용으로 사용 수 있게 Input 컴포넌트를 구현하였습니다.

## 📤 반영 브랜치
feat/input-component -> dev

## 🔧 작업 내용
- 공용으로 사용할 Input 컴포넌트 구현

## 📸 스크린샷
- 공용 컴포넌트이므로 바로 사용하지는 않았으나, 임의로 메인페이지에 넣어본 스크린샷 입니다.
<img width="746" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/36308113/f70a0cf2-22a6-4e74-a8f8-58b8413cd3e8">


## 🔗 관련 이슈
#5 

## 💬 참고사항
