### PR TITLE
design(@): body태그 속성 기본폰트 크기 1.6rem 설정(#16)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,7 @@
 html {
   font-size: 62.5%;
 }
+
+body {
+  font-size: 1.6rem;
+}


### PR DESCRIPTION
기본 폰트 크기를 16px 기준으로  전역으로 적용하기 위해 추가하였습니다.

## 📤 반영 브랜치
feat/body-default-fontsize -> dev

## 🔧 작업 내용
- body 스타일에 `font-size: 1.6rem` 추가


## 🔗 관련 이슈
#11

## 💬 참고사항
