### PR TITLE
feat(@/components/category): 카테고리 버튼 생성(#12)

### DIFF
--- a/src/components/common/category/CategoryButton.tsx
+++ b/src/components/common/category/CategoryButton.tsx
@@ -1,0 +1,42 @@
+import styled, { RuleSet, css } from "styled-components";
+
+interface ButtonProps {
+  variant: "active" | "default";
+  children: string;
+  onClick: () => void;
+}
+
+const VARIANTS = {
+  default: css`
+    background-color: var(--color-gray-100);
+    color: var(--color-black);
+  `,
+  active: css`
+    background-color: var(--color-sub-500);
+    color: var(--color-gray-100);
+    font-weight: var(--weight-bold);
+  `,
+};
+
+const CategoryButton = ({ variant, children, onClick }: ButtonProps) => {
+  const variantStyle = VARIANTS[variant];
+
+  return (
+    <StyledButton $variantStyle={variantStyle} onClick={onClick}>
+      {children}
+    </StyledButton>
+  );
+};
+
+const StyledButton = styled.button<{ $variantStyle: RuleSet<object> }>`
+  ${(props) => props.$variantStyle}
+
+  border-radius: 2px;
+  border: 0;
+
+  padding: 10px 18px;
+
+  cursor: pointer;
+`;
+
+export default CategoryButton;


### PR DESCRIPTION
카테고리 페이지에서 사용할 버튼 컴포넌트를 생성했습니다.
사용하는 컴포넌트 또는 페이지에서 props를 넘겨줍니다.

## 📤 반영 브랜치
`feat/category-button-component` -> `dev`

## 🔧 작업 내용
- active와 default 두 가지 상태로 설정하였습니다.
- 버튼을 클릭하면 해당 버튼의 상태가 변경됩니다. 

## 📸 스크린샷
https://github.com/Eurachacha/hanmogeum/assets/117130358/2f6d539e-12de-4bca-9de4-255d1d3fbb37

## 🔗 관련 이슈
#5 #12

## 💬 참고사항
- 클릭 시 주소 변경 로직을 추가할 예정입니다. 
- 파일 위치 `components/common/category`에서 `components/category`로 변경이 필요합니다. 
