### PR TITLE
chore(Button.tsx): interface를 import문 아래로 이동 (#32)

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,5 +1,17 @@
 import styled, { RuleSet, css } from "styled-components";
 
+interface ButtonProps {
+  value: string;
+  disabled?: boolean;
+  size: "sm" | "md" | "lg";
+  variant: "point" | "sub" | "normal";
+}
+
+interface CustomProperties {
+  $sizeStyle: RuleSet<object>;
+  $variantStyle: RuleSet<object>;
+}
+
 const SIZES = {
   sm: css`
     padding: 1rem;
@@ -38,18 +50,6 @@ const VARIANTS = {
     }
   `,
 };
-
-interface ButtonProps {
-  value: string;
-  disabled?: boolean;
-  size: "sm" | "md" | "lg";
-  variant: "point" | "sub" | "normal";
-}
-
-interface CustomProperties {
-  $sizeStyle: RuleSet<object>;
-  $variantStyle: RuleSet<object>;
-}
 
 const Button = ({ value, disabled = false, size, variant }: ButtonProps) => {
   const sizeStyle = SIZES[size];


### PR DESCRIPTION
## 📤 반영 브랜치
feat/common-button-component -> dev

## 🔧 작업 내용
- 코드 컨벤션에 따라 interface를 import문 하위로 이동