### PR TITLE
feat(@/components/product): 상품 아이템 컴포넌트 라벨 생성 (#21)

### DIFF
--- a/src/components/product/ProductItemLabel.tsx
+++ b/src/components/product/ProductItemLabel.tsx
@@ -1,0 +1,47 @@
+import styled, { RuleSet, css } from "styled-components";
+
+interface LabelProps {
+  variant: "new" | "best" | "decaf";
+  children: string;
+}
+
+const VARIANTS = {
+  new: css`
+    background-color: var(--color-sub-500);
+  `,
+
+  best: css`
+    background-color: var(--color-main);
+  `,
+
+  decaf: css`
+    background-color: var(--color-gray-500);
+  `,
+}
+
+const ProductItemLabel = ({ variant, children }: LabelProps) => {
+  const variantStyle = VARIANTS[variant];
+
+  return (
+    <ProductItemLabelLayer $variantStyle={variantStyle}>
+      {children}
+    </ProductItemLabelLayer>
+  );
+};
+export default ProductItemLabel;
+
+
+const ProductItemLabelLayer = styled.span<{ $variantStyle: RuleSet<object> }>`
+  ${(props) => props.$variantStyle}
+
+  color: var(--color-white);
+
+  border-radius: 5px;
+  border: 0;
+
+  padding: 4px 8px;
+  font-size: 1.2rem;
+
+  cursor: pointer;
+`;
+


### PR DESCRIPTION
## 📤 반영 브랜치
ex) feat/category-button-list-label-component -> dev

## 🔧 작업 내용
상품 아이템 상단에 라벨을 제작하였습니다.
스타일 컴포넌트로 variant로 props를 넘겨 사용할 수 있습니다.

## 📸 스크린샷
<img width="323" alt="product-item-label" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/c26fa3fb-ab37-4c0f-bbf7-3b655b1e8ca5">
린샷

## 🔗 관련 이슈
ex) #21

## 💬 참고사항
관련 없는 작업의 브랜치를 나누는 것을 잊고 작업하여 cherry-pick이라는 명령어를 사용하여 브랜치를 분기하였습니다. 
참고한 사이트: [[링크] [Git] Pull Request 반으로 쪼개기](https://cometj03.github.io/posts/how-to-split-pull-request/)