### PR TITLE
fix(@/components): 상품 아이템 라벨 props 속성 추가(#21)

### DIFF
--- a/src/components/product/ProductItemLabel.tsx
+++ b/src/components/product/ProductItemLabel.tsx
@@ -2,6 +2,8 @@ import styled, { RuleSet, css } from "styled-components";
 
 interface LabelProps {
   variant: "new" | "best" | "decaf";
+  padding: string;
+  margin: string;
   children: string;
 }
 
@@ -19,11 +21,11 @@ const VARIANTS = {
   `,
 }
 
-const ProductItemLabel = ({ variant, children }: LabelProps) => {
+const ProductItemLabel = ({ variant, children, padding, margin }: LabelProps) => {
   const variantStyle = VARIANTS[variant];
 
   return (
-    <ProductItemLabelLayer $variantStyle={variantStyle}>
+    <ProductItemLabelLayer padding={padding} margin={margin} $variantStyle={variantStyle}>
       {children}
     </ProductItemLabelLayer>
   );
@@ -31,7 +33,7 @@ const ProductItemLabel = ({ variant, children }: LabelProps) => {
 export default ProductItemLabel;
 
 
-const ProductItemLabelLayer = styled.span<{ $variantStyle: RuleSet<object> }>`
+const ProductItemLabelLayer = styled.span<{ padding: string, margin: string, $variantStyle: RuleSet<object> }>`
   ${(props) => props.$variantStyle}
 
   color: var(--color-white);
@@ -39,8 +41,10 @@ const ProductItemLabelLayer = styled.span<{ $variantStyle: RuleSet<object> }>`
   border-radius: 5px;
   border: 0;
 
-  padding: 4px 8px;
   font-size: 1.2rem;
+
+  padding: ${(props) => props.padding};
+  margin: ${(props) => props.margin};
 
   cursor: pointer;
 `;


### PR DESCRIPTION
## 📤 반영 브랜치
ex) feat/product-item-component -> dev

## 🔧 작업 내용
상품 아이템 컴포넌트 상단 라벨에 props 속성을 추가하였습니다.
사용하는 곳에서 padding과 margin 값도 조정할 수 있게 수정하여
컴포넌트를 더욱 범용적으로 사용할 수 있도록 하였습니다.

## 📸 스크린샷

## 🔗 관련 이슈
ex) #21 

## 💬 참고사항
