### PR TITLE
feat(Login): 로그인 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "styled-components": "^6.1.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,20 @@
 import "@/App.css";
 import { Outlet } from "react-router-dom";
 import styled from "styled-components";
+import { RecoilRoot } from "recoil";
+
 import Header from "@/components/common/Header";
 import Footer from "@/components/common/Footer";
 
 const App = () => {
   return (
-    <>
+    <RecoilRoot>
       <Header />
       <ContentsWrapper>
         <Outlet />
       </ContentsWrapper>
       <Footer />
-    </>
+    </RecoilRoot>
   );
 };
 

--- a/src/constants/localstorageKeys.ts
+++ b/src/constants/localstorageKeys.ts
@@ -1,0 +1,1 @@
+export const LOGIN_USER_INFO_KEY = "loggedInUser";

--- a/src/containers/LoginContainer/LoginContainer.tsx
+++ b/src/containers/LoginContainer/LoginContainer.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import styled from "styled-components";
+import { NavLink, useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import loggedInUserState from "@/recoil/atoms/loggedInUserState";
+import userApi from "@/apis/services/users";
+// component
+import Input from "@/components/common/Input";
+import Button from "@/components/common/Button";
+import Modal from "@/components/common/Modal";
+// constant
+import { AUTH_TOKEN_KEY } from "@/constants/api";
+
+const LoginContainer = () => {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const setLoggedInUserState = useSetRecoilState(loggedInUserState);
+  const [showLoginCheckAlert, setShowLoginCheckAlert] = useState(false);
+  const loginFailMessage = "아이디와 패스워드를 확인해주세요.";
+
+  const loginHandleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const credentials = { email, password };
+      const { data } = await userApi.loginUser(credentials);
+      if (data.ok === 1) {
+        setLoggedInUserState(data.item);
+        navigate("/");
+        localStorage.setItem(AUTH_TOKEN_KEY, data.item.token.accessToken);
+      }
+    } catch (error) {
+      setShowLoginCheckAlert(true);
+    }
+  };
+
+  return (
+    <LoginContainerLayer onSubmit={loginHandleSubmit}>
+      <InputWrapper>
+        {showLoginCheckAlert && (
+          <LoginCheckModalWrapper>
+            <Modal isOpen={showLoginCheckAlert} iconRequired={false} message={loginFailMessage}>
+              <LoginCheckModalButton
+                onClick={() => {
+                  setShowLoginCheckAlert(false);
+                }}
+              >
+                확인
+              </LoginCheckModalButton>
+            </Modal>
+          </LoginCheckModalWrapper>
+        )}
+        <Input
+          type="email"
+          placeholder="이메일을 입력해주세요"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="비밀번호를 입력해주세요"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+        />
+      </InputWrapper>
+      <ButtonWrapper>
+        <div>
+          <Button size="lg" value="로그인" variant="point" />
+        </div>
+        <div>
+          <NavLink to="/signUp">
+            <Button size="lg" value="화원가입" variant="sub" />
+          </NavLink>
+        </div>
+      </ButtonWrapper>
+    </LoginContainerLayer>
+  );
+};
+
+const LoginContainerLayer = styled.form`
+  margin: auto;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  align-items: center;
+  height: 28rem;
+  max-width: 34rem;
+`;
+
+const LoginCheckModalWrapper = styled.div`
+  position: absolute;
+  color: var(--color-black);
+  font-weight: var(--weight-bold);
+`;
+const LoginCheckModalButton = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 1.8rem 0 0.2rem 0;
+  width: 100%;
+  border-top: 1px solid var(--color-gray-100);
+  color: var(--color-sub-500);
+  font-size: 1.6rem;
+  cursor: pointer;
+`;
+
+const InputWrapper = styled.div`
+  flex-direction: column;
+  align-items: center;
+  input {
+    width: 100%;
+    height: 5rem;
+    margin-bottom: 1.4rem;
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  width: 100%;
+  & > * {
+    height: 5.2rem;
+    margin-top: 1.5rem;
+  }
+`;
+
+export default LoginContainer;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,14 @@
+import ContentsTitle from "@/components/ContentsTitle/ContentsTitle";
+import LoginContainer from "@/containers/LoginContainer/LoginContainer";
+
 const LoginPage = () => {
-  return <div>로그인 페이지</div>;
+  return (
+    <div>
+      로그인 페이지
+      <ContentsTitle title="로그인" />
+      <LoginContainer />
+    </div>
+  );
 };
 
 export default LoginPage;

--- a/src/recoil/atoms/loggedInUserState.ts
+++ b/src/recoil/atoms/loggedInUserState.ts
@@ -1,0 +1,16 @@
+import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+import { User } from "@/types/users";
+import { LOGIN_USER_INFO_KEY } from "@/constants/localstorageKeys";
+
+const { persistAtom } = recoilPersist({ key: LOGIN_USER_INFO_KEY });
+
+type LoggedInUserState = User | null;
+
+const loggedInUserState = atom<LoggedInUserState>({
+  key: "loggedInUserState",
+  default: null,
+  effects: [persistAtom],
+});
+
+export default loggedInUserState;

--- a/src/recoil/selectors/getUserIdState.ts
+++ b/src/recoil/selectors/getUserIdState.ts
@@ -1,0 +1,17 @@
+import { selector } from "recoil";
+import loggedInUserState from "../atoms/loggedInUserState";
+
+const getUserIdState = selector({
+  key: "userIdState",
+  get: ({ get }) => {
+    const userInfo = get(loggedInUserState);
+    if (userInfo === null) {
+      return null;
+    }
+    // response 데이터 구조에 담긴 "_id"명을 유지하기 위해 다음 줄은 eslint를 disable 처리 함
+    // eslint-disable-next-line no-underscore-dangle
+    return userInfo._id;
+  },
+});
+
+export default getUserIdState;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/login -> dev

## 🔧 작업 내용
-   recoil-persist 설치
-  사용자 정보 상태관리 atom, selector 추가
-  로그인 페이지 구현

## 📸 스크린샷
![image](https://github.com/Eurachacha/hanmogeum/assets/36308113/2c187df4-678e-4035-8721-995082ce44a1)


## 🔗 관련 이슈

## 💬 참고사항
