### PR TITLE
feat(product): 상품 아이템과 아이템 리스트 구현(#21)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.20.0",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "styled-components": "^6.1.1"
       },
       "devDependencies": {
@@ -5276,6 +5277,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/src/components/product/ProductItem.tsx
+++ b/src/components/product/ProductItem.tsx
@@ -1,0 +1,109 @@
+import styled from "styled-components";
+import ProductItemLabel from "./ProductItemLabel";
+import { Product } from "@/types/products";
+
+interface ProductItemProps {
+  product: Product;
+}
+
+const ProductItem = ({ product }: ProductItemProps) => {
+  return (
+    <ProductItemLayer>
+      <ProductItemImageWrapper imageUrl={product.mainImages}>
+        <StyledLabel>
+          <li>
+            <ProductItemLabel padding="6px 10px" margin="0 8px 0 0" variant="new">new</ProductItemLabel>
+            <ProductItemLabel padding="6px 10px" margin="0 8px 0 0" variant="best">best</ProductItemLabel>
+          </li>
+          <li>
+            <ProductItemLabel padding="6px 10px" margin="0 0 8px 0" variant="decaf">디카페인</ProductItemLabel>
+          </li>
+        </StyledLabel>
+      </ProductItemImageWrapper>
+
+      <ProductItemContentWrapper>
+        <ul>
+          <StyledTeaType>
+            <p>{product.extra.teaType}</p>
+          </StyledTeaType>
+          <StyledName>
+            <h3>{product.name}</h3>
+          </StyledName>
+          <StyledPrice>
+            <h2>{product.price}</h2>
+          </StyledPrice>
+
+          <StyledHashTag>
+            <p>{product.extra.hashTag.map((hashtag) => {
+              return `#${hashtag} `
+            })}</p>
+          </StyledHashTag>
+        </ul>
+      </ProductItemContentWrapper>
+    </ProductItemLayer>
+  );
+}
+
+export default ProductItem;
+
+const ProductItemLayer = styled.div`
+  width: 100%;
+  background-color: var(--color-white);
+
+  border-radius: 5px;
+  overflow: hidden;
+  box-shadow: 0 6px 6px -3px rgba(0, 0, 0, 0.2);
+`
+
+const ProductItemImageWrapper = styled.div`
+  width: 100%;
+  aspect-ratio: 1/0.5;
+  overflow: hidden;
+
+  background: url(${(props) => props.imageUrl}) no-repeat;
+  background-size: cover;
+`
+const StyledLabel = styled.ul`
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 14px;
+`
+const ProductItemContentWrapper = styled.div`
+  padding: 18px 14px;
+`
+
+const StyledTeaType = styled.li`
+  font-size: 1.2rem;
+  color: var(--color-gray-300);
+
+  margin-bottom: 10px;
+`
+
+const StyledName = styled.li`
+  line-height: 2.4rem;
+`
+
+const StyledPrice = styled.li`
+  text-align: right;
+  font-weight: var(--weight-extrabold);
+
+  margin-top: 10px;
+`
+
+const StyledHashTag = styled.li`
+  & ::before {
+    content: "";
+
+    display: block;
+    width: 100%;
+    height: 1px;
+    background-color: var(--color-gray-100);
+
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  color: var(--color-gray-300);
+  font-size: 1.2rem;
+  line-height: 2.4rem;
+`

--- a/src/components/product/ProductItemList.tsx
+++ b/src/components/product/ProductItemList.tsx
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+import { useEffect, useState } from "react";
+
+import productsApi from "@/apis/services/products";
+import ProductItem from "./ProductItem";
+import { ResponseProductsList } from "@/types/products";
+
+const ProductItemList = () => {
+  const [products, setProducts] = useState<ResponseProductsList[]>([]);
+
+  useEffect(() => {
+    productsApi.getAllProducts().then(response => {
+      setProducts(response.data.item);
+    })
+  }, []);
+
+  return (
+    <ProductItemListLayer>
+      {
+        products && products.map(product => {
+          return <ProductItem product={product} />
+        })
+      }
+    </ProductItemListLayer>
+  )
+}
+
+export default ProductItemList;
+
+const ProductItemListLayer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+`


### PR DESCRIPTION
상품 아이템과 해당 아이템 목록 컴포넌트를 구현했습니다.
상품 아이템에 대한 데이터를 ProductItemList에서 get 하였습니다.

## 📤 반영 브랜치
ex) feat/product-item-component -> dev

## 🔧 작업 내용
- 상품 아이템과 해당 아이템 리스트를 보여주는 컴포넌트를 생성했습니다. 

## 📸 스크린샷
<img width="702" alt="productItemList" src="https://gi#21 b.com/Eurachacha/hanmogeum/assets/117130358/9ef343a8-dd7e-4e63-bc9c-0a80805aa18a">


## 🔗 관련 이슈
ex) #21

## 💬 참고사항
ProductItemList에서 get 해온 데이터를 ProductListPage에서 get 해오는 방식으로 수정할 계획입니다.
