### PR TITLE
feat(SignUp): 회원가입 페이지 구현

### DIFF
--- a/src/apis/services/users.ts
+++ b/src/apis/services/users.ts
@@ -1,7 +1,16 @@
 import { publicInstance, privateInstance } from "../instance";
-import { LoginData, SignUpData, ResponseLogin, ResponseSignUp, ResponseUpdateUser } from "@/types/users";
+import {
+  LoginData,
+  SignUpData,
+  ResponseLogin,
+  ResponseSignUp,
+  ResponseUpdateUser,
+  ResponseEmailDuplicateCheck,
+} from "@/types/users";
 
 const userApi = {
+  emailDuplicateCheck: (email: string) =>
+    publicInstance.get<ResponseEmailDuplicateCheck>(`/users/email?email=${email}`),
   loginUser: (credentials: LoginData) => publicInstance.post<ResponseLogin>("/users/login", credentials),
   signUpUser: (data: SignUpData) => publicInstance.post<ResponseSignUp>("/users", data),
   getUserProfile: (_id: number) => privateInstance.get<ResponseUpdateUser>(`/users/${_id}`),

--- a/src/components/ItemInput/ItemInput.tsx
+++ b/src/components/ItemInput/ItemInput.tsx
@@ -1,0 +1,111 @@
+import styled from "styled-components";
+import Input from "@/components/common/Input";
+import Button from "@/components/common/Button";
+
+interface CommonCustomStyle {
+  width?: string;
+  height?: string;
+  "font-size"?: string;
+  color?: string;
+  margin?: string;
+  padding?: string;
+}
+
+/*
+  title : input 타이틀
+  isTitleImportant?: 타이틀에 중요표시 여부
+  inputValue: input 값
+  inputOnChange: input onChange 핸들러
+  includeButton?: 버튼 클릭 포함 여/부
+  isInputExpand?: input 칸을 버튼칸까지 확장 여/부
+
+  // custom style
+  titleCustomStyle?: title 스타일 세부 설정
+  itemInputCustomStyle?: itemInput 스타일 세부 설정
+  inputCustomStyle?: input 스타일 세부 설정
+  buttonCustomStyle?: button 스타일 세부 설정
+ */
+interface ItemInputProps {
+  title?: string | null;
+  isTitleImportant?: boolean;
+  inputValue: string;
+  inputOnChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  includeButton?: boolean;
+  isInputExpand?: boolean;
+
+  // custom style
+  titleCustomStyle?: CommonCustomStyle;
+  itemInputCustomStyle?: CommonCustomStyle;
+  inputCustomStyle?: CommonCustomStyle;
+  buttonCustomStyle?: CommonCustomStyle;
+}
+
+const ItemInput = ({
+  title = null,
+  isTitleImportant = false,
+  inputValue = "",
+  inputOnChange = () => {},
+  includeButton = false,
+  isInputExpand = false,
+
+  // custom style
+  titleCustomStyle = {},
+  itemInputCustomStyle = {},
+  inputCustomStyle = {},
+  buttonCustomStyle = {},
+}: ItemInputProps) => {
+  return (
+    <ItemInputLayer $itemInputCustomStyle={itemInputCustomStyle}>
+      {title && (
+        <TitleWrapper $titleCustomStyle={titleCustomStyle}>
+          {title}
+          {isTitleImportant && <IsTitleImportant>*</IsTitleImportant>}
+        </TitleWrapper>
+      )}
+      <InputWrapper $inputCustomStyle={inputCustomStyle}>
+        <Input onChange={inputOnChange} value={inputValue} />
+      </InputWrapper>
+      {includeButton && !isInputExpand && (
+        <ButtonWrapper $buttonCustomStyle={buttonCustomStyle}>
+          {includeButton && <Button value="입력" size="md" variant="sub" />}
+        </ButtonWrapper>
+      )}
+    </ItemInputLayer>
+  );
+};
+
+const ItemInputLayer = styled.div<{ $itemInputCustomStyle: React.CSSProperties }>`
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  font-size: 1.4rem;
+  gap: 1rem;
+  ${(props) => props.$itemInputCustomStyle && { ...props.$itemInputCustomStyle }}
+`;
+const TitleWrapper = styled.span<{ $titleCustomStyle: React.CSSProperties }>`
+  font-weight: var(--weight-extrabold);
+  min-width: 10rem;
+  ${(props) => props.$titleCustomStyle && { ...props.$titleCustomStyle }}
+`;
+const IsTitleImportant = styled.span`
+  color: var(--color-red);
+`;
+const InputWrapper = styled.div<{ $inputCustomStyle: React.CSSProperties }>`
+  width: auto;
+  height: 100%;
+  flex-grow: 1;
+  input {
+    height: 100%;
+    padding: 1rem;
+  }
+  ${(props) => props.$inputCustomStyle && { ...props.$inputCustomStyle }}
+`;
+const ButtonWrapper = styled.div<{ $buttonCustomStyle: React.CSSProperties }>`
+  width: 11rem;
+  font-size: 1.6rem;
+  ${(props) => props.$buttonCustomStyle && { ...props.$buttonCustomStyle }}
+`;
+
+export default ItemInput;

--- a/src/components/ItemInput/ItemInput.tsx
+++ b/src/components/ItemInput/ItemInput.tsx
@@ -1,15 +1,8 @@
 import styled from "styled-components";
+import { PropsWithChildren } from "react";
 import Input from "@/components/common/Input";
 import Button from "@/components/common/Button";
-
-interface CommonCustomStyle {
-  width?: string;
-  height?: string;
-  "font-size"?: string;
-  color?: string;
-  margin?: string;
-  padding?: string;
-}
+import { ItemInputProps } from "@/types/inputItem";
 
 /*
   title : input 타이틀
@@ -25,66 +18,76 @@ interface CommonCustomStyle {
   inputCustomStyle?: input 스타일 세부 설정
   buttonCustomStyle?: button 스타일 세부 설정
  */
-interface ItemInputProps {
-  title?: string | null;
-  isTitleImportant?: boolean;
-  inputValue: string;
-  inputOnChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  includeButton?: boolean;
-  isInputExpand?: boolean;
-
-  // custom style
-  titleCustomStyle?: CommonCustomStyle;
-  itemInputCustomStyle?: CommonCustomStyle;
-  inputCustomStyle?: CommonCustomStyle;
-  buttonCustomStyle?: CommonCustomStyle;
-}
-
 const ItemInput = ({
   title = null,
   isTitleImportant = false,
-  inputValue = "",
-  inputOnChange = () => {},
+
+  // button
+  buttonValue = "",
+  buttonOnClick = () => {},
+  buttonDisabled = false,
   includeButton = false,
+
+  // input
   isInputExpand = false,
+  inputProps = { value: "", onChange: () => {} },
+  showValidationMessage = false,
+  validationMessage = "",
 
   // custom style
   titleCustomStyle = {},
   itemInputCustomStyle = {},
   inputCustomStyle = {},
   buttonCustomStyle = {},
-}: ItemInputProps) => {
+  children,
+}: PropsWithChildren<ItemInputProps>) => {
   return (
-    <ItemInputLayer $itemInputCustomStyle={itemInputCustomStyle}>
-      {title && (
-        <TitleWrapper $titleCustomStyle={titleCustomStyle}>
-          {title}
-          {isTitleImportant && <IsTitleImportant>*</IsTitleImportant>}
-        </TitleWrapper>
-      )}
-      <InputWrapper $inputCustomStyle={inputCustomStyle}>
-        <Input onChange={inputOnChange} value={inputValue} />
-      </InputWrapper>
-      {includeButton && !isInputExpand && (
-        <ButtonWrapper $buttonCustomStyle={buttonCustomStyle}>
-          {includeButton && <Button value="입력" size="md" variant="sub" />}
-        </ButtonWrapper>
-      )}
+    <ItemInputLayer>
+      <ItemInputWrapper $itemInputCustomStyle={itemInputCustomStyle}>
+        {title && (
+          <TitleWrapper $titleCustomStyle={titleCustomStyle}>
+            {title}
+            {isTitleImportant && <IsTitleImportant>*</IsTitleImportant>}
+          </TitleWrapper>
+        )}
+        {children}
+        <InputWrapper $inputCustomStyle={inputCustomStyle}>
+          <Input {...inputProps} />
+        </InputWrapper>
+        {(includeButton || !isInputExpand) && (
+          <ButtonWrapper onClick={buttonOnClick} $buttonCustomStyle={buttonCustomStyle}>
+            {includeButton && <Button disabled={buttonDisabled} value={buttonValue} size="md" variant="sub" />}
+          </ButtonWrapper>
+        )}
+      </ItemInputWrapper>
+      {showValidationMessage && <ValidationMessage>{validationMessage}</ValidationMessage>}
     </ItemInputLayer>
   );
 };
 
-const ItemInputLayer = styled.div<{ $itemInputCustomStyle: React.CSSProperties }>`
+const ItemInputLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+const ItemInputWrapper = styled.div<{ $itemInputCustomStyle: React.CSSProperties }>`
   position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   width: 100%;
   font-size: 1.4rem;
+  margin-bottom: 1rem;
   gap: 1rem;
+
   ${(props) => props.$itemInputCustomStyle && { ...props.$itemInputCustomStyle }}
 `;
 const TitleWrapper = styled.span<{ $titleCustomStyle: React.CSSProperties }>`
+  display: flex;
+
   font-weight: var(--weight-extrabold);
   min-width: 10rem;
   ${(props) => props.$titleCustomStyle && { ...props.$titleCustomStyle }}
@@ -93,15 +96,23 @@ const IsTitleImportant = styled.span`
   color: var(--color-red);
 `;
 const InputWrapper = styled.div<{ $inputCustomStyle: React.CSSProperties }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   width: auto;
-  height: 100%;
   flex-grow: 1;
   input {
+    padding: 1.2rem;
+    font-size: 1.6rem;
     height: 100%;
-    padding: 1rem;
   }
   ${(props) => props.$inputCustomStyle && { ...props.$inputCustomStyle }}
 `;
+const ValidationMessage = styled.div`
+  color: var(--color-red);
+  font-size: 1.3rem;
+`;
+
 const ButtonWrapper = styled.div<{ $buttonCustomStyle: React.CSSProperties }>`
   width: 11rem;
   font-size: 1.6rem;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,36 +1,5 @@
 import styled, { css, RuleSet } from "styled-components";
-/**
- * InputType : input태그의 type 형태 중 글자 입력 형태의 목록
- */
-type InputType = "text" | "email" | "password" | "search" | "tel" | "url";
-
-/**
- * inputStyle : 정의된 input 태그의 style 목록
- */
-type InputStyle = "normal";
-
-interface CustomStyle {
-  "font-size"?: string;
-  color?: string;
-  padding?: string;
-  margin?: string;
-}
-
-/**
- * Input 컴포넌트의 props
- */
-interface InputProps {
-  type?: InputType;
-  placeholder?: string;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
-  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
-  onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
-  value: string;
-  disabled?: boolean;
-  inputStyle?: InputStyle; // 정의된 스타일을 적용
-  customStyle?: CustomStyle; // 사용자 정의 스타일을 추가
-}
+import { InputProps } from "@/types/input";
 
 const Input = ({
   type = "text",
@@ -40,15 +9,22 @@ const Input = ({
   onBlur = () => {},
   onKeyDown = () => {},
   value,
+  name = "",
   disabled = false,
   inputStyle = "normal",
   customStyle = {},
+  required = false,
+  minLength,
+  maxLength,
+  min,
+  max,
 }: InputProps) => {
   const currentStyle = INPUT_STYLES[inputStyle];
   return (
     <InputContainer
       type={type}
       value={value}
+      name={name}
       placeholder={placeholder}
       onChange={onChange}
       onFocus={onFocus}
@@ -57,6 +33,11 @@ const Input = ({
       disabled={disabled}
       $inputStyle={currentStyle}
       $customStyle={customStyle}
+      required={required}
+      minLength={minLength}
+      maxLength={maxLength}
+      min={min}
+      max={max}
     ></InputContainer>
   );
 };

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -72,6 +72,7 @@ const INPUT_STYLES = Object.freeze({
 
 const InputContainer = styled.input<{ $inputStyle: RuleSet<object>; $customStyle: React.CSSProperties }>`
   ${(props) => props.$inputStyle};
+  width: inherit;
   border-radius: var(--radius-input);
   border-style: solid;
   border-width: 1px;

--- a/src/constants/signUpValidation.ts
+++ b/src/constants/signUpValidation.ts
@@ -1,0 +1,3 @@
+const PASSWORD_MIN_LENGTH = 8;
+
+export default PASSWORD_MIN_LENGTH;

--- a/src/containers/SignUpContainer/SignUpContainer.tsx
+++ b/src/containers/SignUpContainer/SignUpContainer.tsx
@@ -1,0 +1,407 @@
+import styled from "styled-components";
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import loggedInUserState from "@/recoil/atoms/loggedInUserState";
+/* types */
+import { InputType, InputProps } from "@/types/input";
+import { CommonCustomStyle } from "@/types/inputItem";
+/* components */
+import ItemInput from "@/components/ItemInput/ItemInput";
+import Button from "@/components/common/Button";
+import Modal from "@/components/common/Modal";
+/* util */
+import autoHypenPhone from "@/utils/autoHypenPhonNumber";
+/* api */
+import userApi from "@/apis/services/users";
+/* constants */
+import PASSWORD_MIN_LENGTH from "@/constants/signUpValidation";
+import { AUTH_TOKEN_KEY } from "@/constants/api";
+
+interface InputDataType {
+  title: string;
+  showValidationMessage: boolean;
+  validationMessage?: string;
+  type?: InputType;
+  isTitleImportant?: boolean;
+  inputProps: InputProps;
+  includeButton?: boolean;
+  buttonValue?: string;
+  buttonOnClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  buttonDisabled?: boolean;
+}
+
+interface SignUpDataType {
+  email: string;
+  password: string;
+  passwordAgain: string;
+  name: string;
+  phoneNumber: string;
+  address: string;
+  addressDetail: string;
+}
+
+const inputCustomStyle: CommonCustomStyle = { width: "32rem" };
+
+const SignUpContainer = () => {
+  const navigate = useNavigate();
+
+  const [signUpData, setSignUpData] = useState<SignUpDataType>({
+    email: "",
+    password: "",
+    passwordAgain: "",
+    name: "",
+    phoneNumber: "",
+    address: "",
+    addressDetail: "",
+  });
+  const [validationMessage, setValidationMessage] = useState({
+    email: "",
+    password: "",
+    passwordAgain: "",
+    phoneNumber: "",
+  });
+  const [showModal, setShowModal] = useState({ isOpen: false, message: "" });
+  const [isActiveSignUpButton, setIsActiveSignUpButton] = useState(false);
+  const [isActiveEmailButton, setIsActiveEmailButton] = useState(true);
+  const setLoggedInUserState = useSetRecoilState(loggedInUserState);
+
+  // 가입하기 버튼을 눌렀을 때 발생하는 이벤트 함수입니다.
+  const signUpSubmitClick = async () => {
+    const onlyNumberPhone = signUpData.phoneNumber.replace(/[^0-9]/, "");
+    try {
+      const response = await userApi.signUpUser({
+        email: signUpData.email,
+        password: signUpData?.password,
+        name: signUpData.name,
+        phone: onlyNumberPhone,
+        address: `${signUpData.address + signUpData.addressDetail}`,
+        type: "user",
+      });
+      if (response.data.ok === 1) {
+        const credentials = { email: signUpData.email, password: signUpData.password };
+        const { data } = await userApi.loginUser(credentials);
+        if (data.ok === 1) {
+          setLoggedInUserState(data.item);
+          localStorage.setItem(AUTH_TOKEN_KEY, data.item.token.accessToken);
+          navigate("/");
+        }
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // 입력 필드가 변경될 때마다 값을 저장하는 함수입니다.
+  const inputHandleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const { name, value } = event.target;
+    setSignUpData((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }));
+  };
+
+  // 이메일 중복확인 버튼을 눌렀을때 발생하는 이벤트 함수입니다.
+  const emailDuplicateHandleClick = async (event: React.MouseEvent<HTMLDivElement>) => {
+    /// users/email?email=s1@market.com
+    try {
+      const { data } = await userApi.emailDuplicateCheck(signUpData.email);
+      if (data.ok === 1) {
+        // 사용 가능한 이메일
+        setShowModal({ isOpen: true, message: "가입 가능한 이메일 입니다." });
+        setIsActiveEmailButton(false);
+      } else if (data.ok === 0) {
+        // 사용 불가능한 이메일
+        setShowModal({ isOpen: true, message: "이미 가입한 이메일 입니다." });
+        setIsActiveEmailButton(true);
+      }
+    } catch (error) {
+      console.error(error);
+      setShowModal({ isOpen: true, message: "유효하지 않은 이메일 형식입니다." });
+      setIsActiveEmailButton(true);
+    }
+  };
+
+  // TODO: 카카오 API 붙이기
+  const addressSearchHandleClick = (event: React.MouseEvent<HTMLDivElement>) => {};
+
+  // 가입하기 버튼을 눌렀을때 발생하는 이벤트 함수입니다.
+  const signUpFormHandleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  // TODO: 다음 useEffect들 커스텀 훅으로 변경
+  useEffect(() => {
+    if (
+      validationMessage.email === "" &&
+      validationMessage.password === "" &&
+      validationMessage.passwordAgain === "" &&
+      validationMessage.phoneNumber === "" &&
+      signUpData.name !== "" &&
+      isActiveEmailButton === false
+    ) {
+      setIsActiveSignUpButton(true);
+    } else {
+      setIsActiveSignUpButton(false);
+    }
+  }, [signUpData, isActiveEmailButton]);
+
+  useEffect(() => {
+    setIsActiveEmailButton(true);
+    if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(signUpData.email)) {
+      setValidationMessage((prevState) => ({ ...prevState, email: "" }));
+    } else {
+      setValidationMessage((prevState) => ({ ...prevState, email: "유효한 이메일 주소를 입력해주세요." }));
+    }
+  }, [signUpData.email]);
+
+  useEffect(() => {
+    if (signUpData.password.length < PASSWORD_MIN_LENGTH) {
+      setValidationMessage((prevState) => ({ ...prevState, password: "패스워드는 8글자 이상으로 입력해주세요." }));
+    } else {
+      setValidationMessage((prevState) => ({ ...prevState, password: "" }));
+    }
+  }, [signUpData.password]);
+
+  useEffect(() => {
+    if (signUpData.password !== signUpData.passwordAgain) {
+      setValidationMessage((prevState) => ({ ...prevState, passwordAgain: "동일한 패스워드로 입력해주세요." }));
+    } else {
+      setValidationMessage((prevState) => ({ ...prevState, passwordAgain: "" }));
+    }
+  }, [signUpData.passwordAgain]);
+  useEffect(() => {
+    const formattingPhoneNumber = autoHypenPhone(signUpData.phoneNumber);
+    setSignUpData((prevState) => ({ ...prevState, phoneNumber: formattingPhoneNumber }));
+    if (!/^01[016789]-?\d{3,4}-?\d{4}$/.test(signUpData.phoneNumber)) {
+      setValidationMessage((prevState) => ({ ...prevState, phoneNumber: "올바른 휴대폰 번호를 입력해주세요." }));
+    } else {
+      setValidationMessage((prevState) => ({ ...prevState, phoneNumber: "" }));
+    }
+  }, [signUpData.phoneNumber]);
+
+  // Input 데이터
+  const itemInputData: InputDataType[] = [
+    {
+      // 이메일
+      title: "이메일",
+      isTitleImportant: true,
+      showValidationMessage: validationMessage.email !== "",
+      validationMessage: validationMessage.email,
+      inputProps: {
+        name: "email",
+        type: "email",
+        required: true,
+        placeholder: "이메일을 입력해주세요.",
+        onChange: inputHandleChange,
+        value: signUpData.email,
+        customStyle: inputCustomStyle,
+      },
+      includeButton: true,
+      buttonValue: "중복확인",
+      buttonOnClick: emailDuplicateHandleClick,
+      buttonDisabled: isActiveEmailButton === false,
+    },
+    {
+      // 비밀번호
+      title: "비밀번호",
+      isTitleImportant: true,
+      showValidationMessage: validationMessage.password !== "",
+      validationMessage: validationMessage.password,
+      inputProps: {
+        type: "password",
+        name: "password",
+        required: true,
+        placeholder: "비밀번호를 입력해주세요.",
+        onChange: inputHandleChange,
+        value: signUpData.password,
+        customStyle: inputCustomStyle,
+      },
+      includeButton: false,
+    },
+    {
+      // 비밀번호 확인
+      title: "비밀번호 확인",
+      showValidationMessage: validationMessage.passwordAgain !== "",
+      validationMessage: validationMessage.passwordAgain,
+      isTitleImportant: true,
+
+      inputProps: {
+        type: "password",
+        name: "passwordAgain",
+        required: true,
+        placeholder: "비밀번호를 한번 더 입력해주세요.",
+        onChange: inputHandleChange,
+        value: signUpData.passwordAgain,
+        customStyle: inputCustomStyle,
+      },
+      includeButton: false,
+    },
+    {
+      // 이름
+      title: "이름",
+      showValidationMessage: false,
+      isTitleImportant: true,
+      inputProps: {
+        type: "text",
+        name: "name",
+        required: true,
+        placeholder: "이름을 입력해주세요",
+        onChange: inputHandleChange,
+        value: signUpData.name,
+        customStyle: inputCustomStyle,
+      },
+      includeButton: false,
+    },
+    {
+      // 휴대폰 번호
+      title: "휴대폰",
+      isTitleImportant: true,
+      showValidationMessage: validationMessage.phoneNumber !== "",
+      validationMessage: validationMessage.phoneNumber,
+      inputProps: {
+        type: "tel",
+        maxLength: 13,
+        name: "phoneNumber",
+        placeholder: "숫자만 입력해주세요.",
+        onChange: inputHandleChange,
+        value: signUpData.phoneNumber,
+        customStyle: inputCustomStyle,
+      },
+      includeButton: false,
+    },
+    {
+      // 주소
+      title: "주소",
+      showValidationMessage: false,
+      isTitleImportant: false,
+      inputProps: {
+        type: "text",
+        name: "address",
+        disabled: true,
+        placeholder: "주소 검색",
+        onChange: inputHandleChange,
+        value: signUpData.address,
+        customStyle: inputCustomStyle,
+      },
+      includeButton: true,
+      buttonValue: "주소검색",
+      buttonOnClick: addressSearchHandleClick,
+    },
+    {
+      // 상세 주소
+      title: "상세주소",
+      showValidationMessage: false,
+      isTitleImportant: false,
+      inputProps: {
+        type: "text",
+        name: "addressDetail",
+        placeholder: "상세 주소를 입력해주세요.",
+        onChange: inputHandleChange,
+        value: signUpData.addressDetail,
+        customStyle: inputCustomStyle,
+      },
+    },
+  ];
+
+  return (
+    <SignUpContainerLayer>
+      <div>
+        <Modal isOpen={showModal.isOpen} iconRequired={false} message={showModal.message}>
+          <CheckModalButton onClick={() => setShowModal({ isOpen: false, message: "" })}>확인</CheckModalButton>
+        </Modal>
+      </div>
+      <NoticeBar>
+        <ImportantSpan>*</ImportantSpan>
+        <span>필수입력사항</span>
+      </NoticeBar>
+      <FromWrapper noValidate onSubmit={signUpFormHandleSubmit}>
+        <InputListStyle>
+          {itemInputData.map((itemInput) => {
+            return (
+              <ItemWrapper key={`${itemInput.inputProps.name}_ItemWrapper`}>
+                <ItemInput
+                  key={`${itemInput.inputProps.name}_ItemInput`}
+                  title={itemInput.title}
+                  isTitleImportant={itemInput.isTitleImportant}
+                  showValidationMessage={itemInput.showValidationMessage}
+                  validationMessage={itemInput.validationMessage}
+                  includeButton={itemInput.includeButton}
+                  inputProps={{ ...itemInput.inputProps }}
+                  buttonValue={itemInput?.buttonValue}
+                  buttonOnClick={itemInput?.buttonOnClick}
+                  buttonDisabled={itemInput?.buttonDisabled}
+                />
+              </ItemWrapper>
+            );
+          })}
+        </InputListStyle>
+        <ButtonWrapper onClick={signUpSubmitClick}>
+          <Button disabled={!isActiveSignUpButton} value="가입하기" size="lg" variant="point"></Button>
+        </ButtonWrapper>
+      </FromWrapper>
+    </SignUpContainerLayer>
+  );
+};
+
+const SignUpContainerLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+`;
+
+const NoticeBar = styled.div`
+  display: flex;
+  justify-content: end;
+  border-bottom: 1px solid var(--color-gray-200);
+  width: 55rem;
+  padding-bottom: 0.8rem;
+  margin-bottom: 2rem;
+  font-size: 1.3rem;
+  font-weight: var(----weight-medium);
+`;
+const ImportantSpan = styled.span`
+  color: var(--color-red);
+`;
+
+const ItemWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const FromWrapper = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 55rem;
+  gap: 5rem;
+  input:invalid {
+    border: 1px solid -var(--color-red);
+  }
+`;
+
+const InputListStyle = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const CheckModalButton = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 1.8rem 0 0.2rem 0;
+  width: 100%;
+  border-top: 1px solid var(--color-gray-100);
+  color: var(--color-sub-500);
+  font-size: 1.6rem;
+  cursor: pointer;
+`;
+const ButtonWrapper = styled.div`
+  border: none;
+  background-color: unset;
+  width: 100%;
+`;
+
+export default SignUpContainer;

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,5 +1,13 @@
+import ContentsTitle from "@/components/ContentsTitle/ContentsTitle";
+import SignUpContainer from "@/containers/SignUpContainer/SignUpContainer";
+
 const SignUpPage = () => {
-  return <div>회원가입 페이지</div>;
+  return (
+    <div>
+      <ContentsTitle title="회원가입" />
+      <SignUpContainer />
+    </div>
+  );
 };
 
 export default SignUpPage;

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -1,0 +1,42 @@
+/**
+ * InputType : input태그의 type 형태 중 글자 입력 형태의 목록
+ */
+export type InputType = "text" | "email" | "password" | "search" | "tel" | "url";
+
+/**
+ * inputStyle : 정의된 input 태그의 style 목록
+ */
+export type InputStyle = "normal";
+
+export interface CustomStyle {
+  "font-size"?: string;
+  color?: string;
+  width?: string;
+  height?: string;
+  padding?: string;
+  margin?: string;
+}
+
+/**
+ * Input 컴포넌트의 props
+ */
+export interface InputProps {
+  type?: InputType;
+  placeholder?: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  value: string;
+  name?: string;
+  // 유효성 검사
+  disabled?: boolean;
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  min?: number;
+  max?: number;
+  pattern?: string;
+  inputStyle?: InputStyle; // 정의된 스타일을 적용
+  customStyle?: CustomStyle; // 사용자 정의 스타일을 추가
+}

--- a/src/types/inputItem.ts
+++ b/src/types/inputItem.ts
@@ -1,0 +1,32 @@
+import { InputProps } from "@/types/input";
+
+export interface CommonCustomStyle {
+  width?: string;
+  height?: string;
+  "font-size"?: string;
+  color?: string;
+  margin?: string;
+  padding?: string;
+}
+export interface ItemInputProps {
+  title?: string | null;
+  isTitleImportant?: boolean;
+
+  // input
+  inputProps?: InputProps;
+  isInputExpand?: boolean;
+  showValidationMessage?: boolean;
+  validationMessage?: string;
+
+  // button
+  includeButton?: boolean;
+  buttonValue?: string | undefined;
+  buttonOnClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  buttonDisabled?: boolean;
+
+  // custom style
+  titleCustomStyle?: CommonCustomStyle;
+  itemInputCustomStyle?: CommonCustomStyle;
+  inputCustomStyle?: CommonCustomStyle;
+  buttonCustomStyle?: CommonCustomStyle;
+}

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -9,8 +9,9 @@ export interface SignUpData {
   email: string;
   password: string;
   name: string;
-  phone: string;
-  address: string;
+  phone?: string;
+  address?: string;
+  type: string;
 }
 
 export interface UserExtra {
@@ -41,6 +42,10 @@ export interface User {
   extra?: UserExtra;
   createdAt: string;
   updatedAt: string;
+}
+export interface ResponseEmailDuplicateCheck {
+  ok: number;
+  message: string;
 }
 
 // POST /users/login 로그인

--- a/src/utils/autoHypenPhonNumber.ts
+++ b/src/utils/autoHypenPhonNumber.ts
@@ -1,0 +1,29 @@
+const autoHypenPhone = (rawString: string) => {
+  const numberString: string = rawString.replace(/[^0-9]/g, "");
+  let result = "";
+  if (numberString.length < 4) {
+    return numberString;
+  }
+  if (numberString.length < 7) {
+    result += numberString.substring(0, 3);
+    result += "-";
+    result += numberString.substring(3);
+    return result;
+  }
+  if (numberString.length < 11) {
+    result += numberString.substring(0, 3);
+    result += "-";
+    result += numberString.substring(3, 6);
+    result += "-";
+    result += numberString.substring(6);
+    return result;
+  }
+  result += numberString.substring(0, 3);
+  result += "-";
+  result += numberString.substring(3, 7);
+  result += "-";
+  result += numberString.substring(7);
+  return result;
+};
+
+export default autoHypenPhone;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/signup -> dev

## 🔧 작업 내용
- design(Input): Input 너비를 상위 컴포넌트 너비를 상속
- feat(Input): input 태그 관련 옵션 추가, 타입 분리
- fix(ItemInput): 컴포넌트 props 속성 수정, 타입 분리 
- fix(user.ts): 회원가입 요청 데이터 수정
- fix(apis/user): 이메일 중복확인 api추가
- feat(utils): autoHypenPhonNumber 함수 추가
**- feat(SignUp): 회원가입 페이지, 컨테이너 구현 ✨ **

## 📸 스크린샷
<img width="1010" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/36308113/6503be5a-e136-4dcf-b84d-8aa2c3c3d0ab">


## 🔗 관련 이슈
#38 

## 💬 참고사항
- Common/Input 컴포넌트 수정
