### PR TITLE
feat(order-checkout): 주문하기페이지 좌측 기본 마크업 완료 (#84)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
     "import/no-extraneous-dependencies": ["off"],
     "arrow-body-style": ["off", "never"],
     "import/extensions": ["off"],
-    "object-shorthand": ["off"]
+    "object-shorthand": ["off"],
+    "no-console": ["error", { "allow": ["warn", "error"] }]
   }
 }

--- a/src/apis/services/cart.ts
+++ b/src/apis/services/cart.ts
@@ -1,0 +1,23 @@
+import { CartItemSummary, RequestCartItem, ResponseAddCartItem, ResponseCartItems } from "@/types/cart";
+import { privateInstance } from "../instance";
+
+const cartApi = {
+  // GET /carts
+  getAllItems: () => privateInstance.get<ResponseCartItems>("/carts"),
+  // POST /carts
+  addItem: (data: RequestCartItem) => privateInstance.post<ResponseCartItems>("/carts", data),
+  // PATCH /carts/:_id
+  updateQuantity: (_id: number, data: { quantity: number }) =>
+    privateInstance.patch<ResponseAddCartItem>(`/carts/${_id}`, data),
+  // PUT /carts/replace
+  replaceCarts: (data: { products: CartItemSummary[] }) =>
+    privateInstance.put<ResponseCartItems>("/carts/replace", data),
+  // PUT /carts
+  combineCarts: (data: { products: CartItemSummary[] }) => privateInstance.put<ResponseCartItems>("/carts", data),
+  // DELETE /carts/_id
+  deleteItem: (_id: number) => privateInstance.delete<{ ok: number }>(`/carts/${_id}`),
+  // DELETE /carts/cleanup
+  deleteAllItems: () => privateInstance.delete<{ ok: number }>("/carts/cleanup"),
+};
+
+export default cartApi;

--- a/src/apis/services/orders.ts
+++ b/src/apis/services/orders.ts
@@ -1,11 +1,11 @@
 import { privateInstance } from "../instance";
-import { RequestOrders, ResponseOrders, ResponseOrderList } from "@/types/orders";
+import { RequestCreateOrder, ResponseCreateOrder, ResponseGetOrderList } from "@/types/orders";
 
 const ordersApi = {
-  // POST/orders
-  postOrder: (data: RequestOrders) => privateInstance.post<ResponseOrders>("/orders", data),
-  // GET/orders
-  getOrderList: () => privateInstance.get<ResponseOrderList>("/orders"),
+  // POST /orders
+  createOrder: (data: { product: RequestCreateOrder[] }) => privateInstance.post<ResponseCreateOrder>("/orders", data),
+  // GET /orders
+  getOrderList: () => privateInstance.get<ResponseGetOrderList>("/orders"),
 };
 
 export default ordersApi;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -69,6 +69,7 @@ const ButtonContainer = styled.button<CustomProperties>`
   ${(props) => props.$variantStyle}
 
   width: 100%;
+  height: 100%;
   margin: 0;
   border-radius: var(--radius-button);
   cursor: pointer;

--- a/src/components/orderCheckout/FormInput.tsx
+++ b/src/components/orderCheckout/FormInput.tsx
@@ -18,6 +18,7 @@ const FormInput = ({ children, title, $marginBottom = "14px" }: PropsWithChildre
 export default FormInput;
 
 const FormInputLayer = styled.div<{ $marginBottom: string }>`
+  padding: 0 4px;
   margin-bottom: ${(props) => props.$marginBottom};
   display: flex;
   align-items: center;
@@ -28,9 +29,12 @@ const FormInputLayer = styled.div<{ $marginBottom: string }>`
   }
 
   input {
-    min-width: 300px;
+    width: 300px;
+    min-width: 200px;
     height: 45px;
-    margin: 0 4px;
+    padding: 8px 12px;
+    margin-left: 14px;
+    margin-right: 4px;
   }
 
   input::placeholder {

--- a/src/components/orderCheckout/FormInput.tsx
+++ b/src/components/orderCheckout/FormInput.tsx
@@ -1,0 +1,40 @@
+import { PropsWithChildren } from "react";
+import styled from "styled-components";
+
+interface FormInputProps {
+  title: string;
+  $marginBottom?: string;
+}
+
+const FormInput = ({ children, title, $marginBottom = "14px" }: PropsWithChildren<FormInputProps>) => {
+  return (
+    <FormInputLayer $marginBottom={$marginBottom}>
+      <p>{title}</p>
+      {children}
+    </FormInputLayer>
+  );
+};
+
+export default FormInput;
+
+const FormInputLayer = styled.div<{ $marginBottom: string }>`
+  margin-bottom: ${(props) => props.$marginBottom};
+  display: flex;
+  align-items: center;
+
+  p {
+    min-width: 60px;
+    font-weight: var(--weight-bold);
+  }
+
+  input {
+    min-width: 300px;
+    height: 45px;
+    margin: 0 4px;
+  }
+
+  input::placeholder {
+    color: var(--color-gray-200);
+    font-weight: var(--weight-light);
+  }
+`;

--- a/src/components/orderCheckout/Info.tsx
+++ b/src/components/orderCheckout/Info.tsx
@@ -1,0 +1,36 @@
+import { styled } from "styled-components";
+
+interface InfoProps {
+  title: string;
+  value: string;
+}
+
+const Info = ({ title, value }: InfoProps) => {
+  return (
+    <InfoLayer>
+      <p>{title}</p>
+      <p>{value}</p>
+    </InfoLayer>
+  );
+};
+
+export default Info;
+
+const InfoLayer = styled.div`
+  font-size: 1.6rem;
+  padding: 0 4px;
+  margin: 12px 0;
+
+  display: flex;
+  align-items: center;
+  p:first-child {
+    font-weight: var(--weight-bold);
+    min-width: 60px;
+  }
+
+  p:last-child {
+    font-weight: var(--weight-medium);
+    margin: 0 10px;
+    padding: 12px;
+  }
+`;

--- a/src/components/orderCheckout/OrderItem.tsx
+++ b/src/components/orderCheckout/OrderItem.tsx
@@ -1,0 +1,70 @@
+import styled from "styled-components";
+
+interface OrderItemProps {
+  imgUrl: string;
+  name: string;
+  quantity: number;
+  priceSum: number;
+}
+
+const OrderItem = ({ imgUrl, name, quantity, priceSum }: OrderItemProps) => {
+  return (
+    <OrderItemLayer>
+      <ItemLeft>
+        <ImageWrapper>
+          <img src={imgUrl} alt={name} width="100%" />
+        </ImageWrapper>
+        <p>{name}</p>
+      </ItemLeft>
+      <ItemRight>
+        <p>{priceSum.toLocaleString()}원</p>
+        <span>/</span>
+        <p>{quantity}개</p>
+      </ItemRight>
+    </OrderItemLayer>
+  );
+};
+
+export default OrderItem;
+
+const OrderItemLayer = styled.li`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+
+  border-bottom: 1px solid var(--color-gray-50);
+  padding: 10px;
+`;
+
+const ItemLeft = styled.div`
+  display: flex;
+  align-items: center;
+  min-width: 200px;
+
+  p {
+    font-size: 1.6rem;
+    margin: 0 8px;
+  }
+`;
+
+const ImageWrapper = styled.div`
+  max-width: 80px;
+  border: 1px solid var(--color-gray-50);
+`;
+
+const ItemRight = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: flex-end;
+
+  p {
+    font-size: 1.6rem;
+    font-weight: var(--weight-bold);
+  }
+
+  span {
+    color: var(--color-gray-300);
+    padding: 0 8px;
+  }
+`;

--- a/src/components/orderCheckout/OrderItem.tsx
+++ b/src/components/orderCheckout/OrderItem.tsx
@@ -33,7 +33,7 @@ const OrderItemLayer = styled.li`
   justify-content: space-between;
   align-items: center;
 
-  border-bottom: 1px solid var(--color-gray-50);
+  border-bottom: 1px solid var(--color-gray-100);
   padding: 10px;
 `;
 
@@ -44,7 +44,7 @@ const ItemLeft = styled.div`
 
   p {
     font-size: 1.6rem;
-    margin: 0 8px;
+    margin: 0 12px;
   }
 `;
 

--- a/src/containers/orderCheckout/InfoContainer.tsx
+++ b/src/containers/orderCheckout/InfoContainer.tsx
@@ -1,0 +1,17 @@
+import { useRecoilValue } from "recoil";
+import Info from "@/components/orderCheckout/Info";
+import loggedInUserState from "@/recoil/atoms/loggedInUserState";
+
+const InfoContainer = () => {
+  const userInfo = useRecoilValue(loggedInUserState);
+
+  return (
+    <>
+      <Info title="이름" value={userInfo ? userInfo.name : ""} />
+      <Info title="전화번호" value={userInfo ? userInfo.phone : ""} />
+      <Info title="이메일" value={userInfo ? userInfo.email : ""} />
+    </>
+  );
+};
+
+export default InfoContainer;

--- a/src/containers/orderCheckout/OrderListContainer.tsx
+++ b/src/containers/orderCheckout/OrderListContainer.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import cartApi from "@/apis/services/cart";
+import OrderItem from "@/components/orderCheckout/OrderItem";
+import { CartItem } from "@/types/cart";
+
+const OrderListContainer = () => {
+  const [cartItems, setCartItems] = useState<CartItem[]>();
+  const fetchAllCartItems = async () => {
+    try {
+      const response = await cartApi.getAllItems();
+      const { item } = response.data;
+      setCartItems(item);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllCartItems();
+  });
+
+  return (
+    <div>
+      {cartItems?.map((item, idx) => {
+        const key = idx.toString();
+        return (
+          <OrderItem
+            key={key}
+            imgUrl={item.product.image}
+            name={item.product.name}
+            quantity={item.quantity}
+            priceSum={item.product.price * item.quantity}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default OrderListContainer;

--- a/src/containers/orderCheckout/OrderListContainer.tsx
+++ b/src/containers/orderCheckout/OrderListContainer.tsx
@@ -17,7 +17,7 @@ const OrderListContainer = () => {
 
   useEffect(() => {
     fetchAllCartItems();
-  });
+  }, []);
 
   return (
     <div>

--- a/src/containers/orderCheckout/ShippingInfoContainer.tsx
+++ b/src/containers/orderCheckout/ShippingInfoContainer.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import styled from "styled-components";
 import Input from "@/components/common/Input";
 import Button from "@/components/common/Button";
 import FormInput from "@/components/orderCheckout/FormInput";
@@ -17,7 +18,7 @@ const ShippingInfoContainer = () => {
   };
 
   return (
-    <>
+    <ShippingInfoContainerLayer>
       <FormInput title="받는 분">
         <Input
           type="text"
@@ -47,12 +48,12 @@ const ShippingInfoContainer = () => {
           inputStyle="normal"
           customStyle={{ padding: "8px", "font-size": "1.4rem" }}
         />
-        <div style={{ display: "flex", flexDirection: "column" }}>
-          <Button value="주소검색" size="md" variant="sub" />
-        </div>
+        <ButtonWrapper>
+          <Button value="주소검색" size="sm" variant="sub" />
+        </ButtonWrapper>
       </FormInput>
       <FormInput title="">
-        <div style={{ display: "flex", flexDirection: "column" }}>
+        <InputWrapper>
           <Input
             type="text"
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange(event, setDetailAddress)}
@@ -61,10 +62,24 @@ const ShippingInfoContainer = () => {
             inputStyle="normal"
             customStyle={{ padding: "8px", "font-size": "1.4rem" }}
           />
-        </div>
+        </InputWrapper>
       </FormInput>
-    </>
+    </ShippingInfoContainerLayer>
   );
 };
 
 export default ShippingInfoContainer;
+
+const ShippingInfoContainerLayer = styled.div`
+  padding: 24px 0;
+`;
+
+const ButtonWrapper = styled.div`
+  height: 45px;
+  min-width: 72px;
+`;
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/containers/orderCheckout/ShippingInfoContainer.tsx
+++ b/src/containers/orderCheckout/ShippingInfoContainer.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import Input from "@/components/common/Input";
+import Button from "@/components/common/Button";
+import FormInput from "@/components/orderCheckout/FormInput";
+
+const ShippingInfoContainer = () => {
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [address, setAddress] = useState("");
+  const [detailAddress, setDetailAddress] = useState("");
+
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    setState: React.Dispatch<React.SetStateAction<string>>,
+  ) => {
+    return setState(event.target.value);
+  };
+
+  return (
+    <>
+      <FormInput title="받는 분">
+        <Input
+          type="text"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange(event, setName)}
+          value={name}
+          placeholder="이름을 입력해주세요."
+          inputStyle="normal"
+          customStyle={{ padding: "8px", "font-size": "1.4rem" }}
+        />
+      </FormInput>
+      <FormInput title="연락처">
+        <Input
+          type="tel"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange(event, setPhone)}
+          value={phone}
+          placeholder="전화번호를 입력해주세요."
+          inputStyle="normal"
+          customStyle={{ padding: "8px", "font-size": "1.4rem" }}
+        />
+      </FormInput>
+      <FormInput title="주소" $marginBottom="4px">
+        <Input
+          type="text"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange(event, setAddress)}
+          value={address}
+          placeholder="주소를 입력해주세요."
+          inputStyle="normal"
+          customStyle={{ padding: "8px", "font-size": "1.4rem" }}
+        />
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <Button value="주소검색" size="md" variant="sub" />
+        </div>
+      </FormInput>
+      <FormInput title="">
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <Input
+            type="text"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange(event, setDetailAddress)}
+            value={detailAddress}
+            placeholder="상세주소를 입력해주세요."
+            inputStyle="normal"
+            customStyle={{ padding: "8px", "font-size": "1.4rem" }}
+          />
+        </div>
+      </FormInput>
+    </>
+  );
+};
+
+export default ShippingInfoContainer;

--- a/src/pages/OrderCheckoutPage.tsx
+++ b/src/pages/OrderCheckoutPage.tsx
@@ -1,5 +1,54 @@
+import { styled } from "styled-components";
+import InfoContainer from "@/containers/orderCheckout/InfoContainer";
+import ShippingInfoContainer from "@/containers/orderCheckout/ShippingInfoContainer";
+import OrderListContainer from "@/containers/orderCheckout/OrderListContainer";
+
 const OrderCheckoutPage = () => {
-  return <div>주문 하기 페이지</div>;
+  return (
+    <OrderCheckoutPageLayer>
+      <OrderInfo>
+        <Section>
+          <SectionTitle>주문 상품</SectionTitle>
+          <OrderListContainer />
+        </Section>
+        <Section>
+          <SectionTitle>주문자 정보</SectionTitle>
+          <InfoContainer />
+        </Section>
+        <Section>
+          <SectionTitle>배송 정보</SectionTitle>
+          <ShippingInfoContainer />
+        </Section>
+      </OrderInfo>
+      <OrderPriceInfo>금액안내</OrderPriceInfo>
+    </OrderCheckoutPageLayer>
+  );
 };
 
 export default OrderCheckoutPage;
+
+const OrderCheckoutPageLayer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const OrderInfo = styled.div`
+  flex: 7;
+  max-width: 700px;
+`;
+
+const Section = styled.section`
+  margin: 40px 0;
+`;
+
+const SectionTitle = styled.p`
+  font-size: 1.8rem;
+  font-weight: var(--weight-bold);
+  padding: 12px 4px;
+  border-bottom: 1px solid var(--color-gray-300);
+`;
+
+const OrderPriceInfo = styled.div`
+  flex: 3;
+  min-width: 300px;
+`;

--- a/src/types/cart.ts
+++ b/src/types/cart.ts
@@ -8,3 +8,46 @@ export interface CartItemInfo {
   stock: number;
   quantity: number;
 }
+
+export interface CartItemSummary {
+  _id: number;
+  quantity: number;
+}
+
+export interface CartItemDetail {
+  name: string;
+  price: number;
+  image: string;
+}
+
+export interface CartItem {
+  _id: number;
+  product_id: number;
+  quantity: number;
+  createdAt: string;
+  updatedAt: string;
+  product: CartItemDetail;
+}
+
+// Request Types
+
+export interface RequestCartItem {
+  product_id: number;
+  quantity: number;
+}
+
+// Reponse Types
+
+export interface ResponseCartItems {
+  ok: number;
+  item: CartItem[];
+}
+
+export interface ResponseAddCartItem {
+  ok: number;
+  updated: {
+    _id: number;
+    quantity: number;
+    updatedAt: string;
+  };
+}

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -1,12 +1,6 @@
-// POST /orders 상품 구매
-export interface RequestOrders {
-  products: OrderProduct[];
-  address: OrderAddress;
-}
-
 interface OrderProduct {
   _id: number;
-  count: number;
+  quantity: number;
 }
 
 interface OrderAddress {
@@ -14,34 +8,53 @@ interface OrderAddress {
   value: string;
 }
 
-export interface ResponseOrders {
-  ok: number;
-  item: OrderItem;
-}
-
-interface OrderItem extends RequestOrders {
-  user_id: number;
-  _id: number;
-  createdAt: string;
-  cost: OrderCost;
-}
-
-interface OrderCost {
-  products: number;
-  shippingFees: number;
-  total: number;
-}
-
-interface OrderProduct {
-  _id: number;
-  quantity: number;
+interface OrderProductDetail extends OrderProduct {
   name: string;
   image: string;
   price: number;
 }
 
-// GET /orders 구매 목록 조회
-export interface ResponseOrderList {
+interface Discount {
+  products: number;
+  shippingFees: number;
+}
+
+interface OrderCost {
+  products: number;
+  shippingFees: number;
+  discount: Discount;
+  total: number;
+}
+
+interface OrderDetail {
+  products: OrderProductDetail[];
+  address: OrderAddress;
+  state: string;
+  user_id: number;
+  _id: number;
+  createdAt: string;
+  updatedAt: string;
+  cost: OrderCost;
+}
+
+// Request Types
+
+// POST /orders 구매 목록 조회
+export interface RequestCreateOrder {
+  products: OrderProduct[];
+  address: OrderAddress;
+}
+
+// Response Types
+
+// POST /orders 구매 목록 조회
+export interface ResponseCreateOrder {
   ok: number;
-  item: OrderItem[];
+  item: OrderDetail;
+}
+
+// GET /orders 구매 목록 조회
+export interface ResponseGetOrderList {
+  ok: number;
+  item: OrderDetail[];
 }


### PR DESCRIPTION
## 📤 반영 브랜치
feat/order-checkout -> dev

## 🔧 작업 내용
- 주문할 상품 정보 출력
- 주문자 정보 출력 (현재 로그인된 유저 정보)
- 배송 정보 input 생성

## 📸 스크린샷
<img width="584" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/6b21a0d4-fded-447c-be60-eb0492f897dd">

## 🔗 관련 이슈
#84

## 💬 참고사항
우측 금액안내 부분은 구현예정입니다.