### PR TITLE
feat(SignUp): 카카오 우편번호 서비스 연동 (#90)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query-devtools": "^5.8.7",
         "axios": "^1.6.2",
         "react": "^18.2.0",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.20.0",
         "recoil": "^0.7.7",
@@ -5210,6 +5211,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query-devtools": "^5.8.7",
     "axios": "^1.6.2",
     "react": "^18.2.0",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",
     "recoil": "^0.7.7",

--- a/src/containers/SignUpContainer/SignUpContainer.tsx
+++ b/src/containers/SignUpContainer/SignUpContainer.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
+import { useDaumPostcodePopup } from "react-daum-postcode";
 import loggedInUserState from "@/recoil/atoms/loggedInUserState";
 /* types */
 import { InputType, InputProps } from "@/types/input";
@@ -17,6 +18,8 @@ import userApi from "@/apis/services/users";
 /* constants */
 import PASSWORD_MIN_LENGTH from "@/constants/signUpValidation";
 import { AUTH_TOKEN_KEY } from "@/constants/api";
+
+import getPostCodeDaum from "@/utils/getPostCodeDaum";
 
 interface InputDataType {
   title: string;
@@ -75,7 +78,7 @@ const SignUpContainer = () => {
         password: signUpData?.password,
         name: signUpData.name,
         phone: onlyNumberPhone,
-        address: `${signUpData.address + signUpData.addressDetail}`,
+        address: `${`${signUpData.address} ${signUpData.addressDetail}`}`,
         type: "user",
       });
       if (response.data.ok === 1) {
@@ -122,8 +125,22 @@ const SignUpContainer = () => {
     }
   };
 
-  // TODO: 카카오 API 붙이기
-  const addressSearchHandleClick = (event: React.MouseEvent<HTMLDivElement>) => {};
+  // TODO: 커스텀 훅 사용하도록 ㄱ수정
+  const openPostcode = useDaumPostcodePopup();
+  const addressSearchHandleClick = () => {
+    openPostcode({
+      onComplete: (data) => {
+        // 주소 검색 결과 처리
+        const fullAddress = data.address;
+        const extraAddress = data.buildingName ? ` (${data.buildingName})` : "";
+        setSignUpData((prevState) => ({
+          ...prevState,
+          address: fullAddress,
+          addressDetail: extraAddress,
+        }));
+      },
+    });
+  };
 
   // 가입하기 버튼을 눌렀을때 발생하는 이벤트 함수입니다.
   const signUpFormHandleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -336,6 +353,7 @@ const SignUpContainer = () => {
             );
           })}
         </InputListStyle>
+
         <ButtonWrapper onClick={signUpSubmitClick}>
           <Button disabled={!isActiveSignUpButton} value="가입하기" size="lg" variant="point"></Button>
         </ButtonWrapper>


### PR DESCRIPTION
## 📤 반영 브랜치
feat/signup-map-api -> dev

## 🔧 작업 내용
- 회원가입 주소찾기 버튼 클릭 시 카카오 우편번호 서비스 연동을 추가하였습니다.
- react-daum-postcode 패키지를 사용하였습니다.

## 📸 스크린샷
<img width="1115" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/36308113/44dbeadb-cb83-4b8e-8274-847051c26208">


## 🔗 관련 이슈
#38

## 💬 참고사항
