### PR TITLE
feat(hooks): 쿼리스트링 저장하는 커스터 훅 추가(#87)

### DIFF
--- a/src/hooks/useQueryParams.tsx
+++ b/src/hooks/useQueryParams.tsx
@@ -1,0 +1,41 @@
+import { useSearchParams } from "react-router-dom";
+
+const useQueryParams = (queryKey: string) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const curQueryData = searchParams.getAll(queryKey) || [];
+
+  const toggleFilter = (categoryName: string) => {
+    if (curQueryData.length === 0) {
+      searchParams.append(queryKey, categoryName);
+      setSearchParams(searchParams);
+    }
+
+    const isExist = curQueryData[0]?.split(" ").includes(categoryName);
+
+    if (isExist) {
+      // 해당 카테고리네임이 존재하므로 지워주는 로직
+      const newQueryData = curQueryData[0].split(" ").filter((item) => item !== categoryName);
+      searchParams.delete(queryKey);
+      searchParams.append(queryKey, newQueryData.join(" "));
+
+      // 지우고 나서 빈문자열이 되면 queryKey까지 다 지워주는 로직
+      if (searchParams.getAll(queryKey)[0] === "") searchParams.delete(queryKey);
+      setSearchParams(searchParams);
+    } else if (curQueryData[0]) {
+      // categoryName이 존재하지는 않지만, 다른 카테고리가 선택되어 있을때
+      // 원래 있던 쿼리스트링과 categoryName 사이에 공백을 넣어 다시 세팅
+      searchParams.delete(queryKey);
+      const newQueryData = `${curQueryData[0]} ${categoryName}`;
+      searchParams.append(queryKey, newQueryData);
+      setSearchParams(searchParams);
+    }
+  };
+
+  const resetFilter = () => {
+    setSearchParams("");
+  };
+
+  return { curQueryData, toggleFilter, resetFilter };
+};
+
+export default useQueryParams;


### PR DESCRIPTION
## 📤 반영 브랜치
ex) feat/product-item-component -> dev

## 🔧 작업 내용
카테고리 클릭 시 쿼리스트링에 반영되는 로직 커스텀훅을 만들었습니다.
같은 카테고리 내 쿼리스트링은 띄어쓰기로 저장하였습니다. 띄어쓰기로 나눠진 쿼리스트링은 주소에서는 +로 표시됩니다. 
쿼리스트링을 이용해 데이터를 필터링할 때 띄어쓰기를 기준으로 배열을 나눠 작업해야 합니다. 

## 📸 스크린샷
https://github.com/Eurachacha/hanmogeum/assets/117130358/fe5ca330-d180-48a0-bf85-48567b463683

## 🔗 관련 이슈
ex) #87

## 💬 참고사항
