### PR TITLE
feat(mypage): 마이페이지에서 공통 컴포넌트, 컨테이너 구현

### DIFF
--- a/src/components/mypage/ContainerHeader..tsx
+++ b/src/components/mypage/ContainerHeader..tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+interface ContainerHeaderProps {
+  title: string;
+}
+
+const ContainerHeader = ({ title }: ContainerHeaderProps) => {
+  return <ContainerHeaderLayer>{title}</ContainerHeaderLayer>;
+};
+
+const ContainerHeaderLayer = styled.div`
+  width: 100%;
+  height: 5rem;
+  font-weight: var(--weight-bold);
+  font-size: 2.4rem;
+  border-bottom: 1px solid var(--color-black);
+`;
+
+export default ContainerHeader;

--- a/src/components/mypage/NavigationMenu.tsx
+++ b/src/components/mypage/NavigationMenu.tsx
@@ -1,0 +1,54 @@
+import styled from "styled-components";
+import { NavLink } from "react-router-dom";
+
+const NavigationMenu = () => {
+  const title = "마이페이지";
+  const navigationData = [
+    { name: "주문내역", router: "/mypage/orders" },
+    { name: "내가 쓴 리뷰", router: "/mypage/reviews" },
+    { name: "내가 찜한 상품", router: "/mypage/likes" },
+    { name: "내 정보 변경", router: "/mypage/profile" },
+  ];
+  return (
+    <NavigationMenuLayer>
+      <TitleWrapper>{title}</TitleWrapper>
+      {navigationData.map((navigationItem) => {
+        return (
+          <ButtonStyle key={navigationItem.name}>
+            <NavStyle to={navigationItem.router}>{navigationItem.name}</NavStyle>
+          </ButtonStyle>
+        );
+      })}
+    </NavigationMenuLayer>
+  );
+};
+
+const NavigationMenuLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+const TitleWrapper = styled.h2`
+  font-size: 2.8rem;
+  font-weight: var(--weight-bold);
+  height: 5rem;
+`;
+const ButtonStyle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 5.4rem;
+  width: 16rem;
+  border: 1px solid var(--color-gray-200);
+  font-weight: var(--weight-bold);
+  color: black;
+`;
+
+const NavStyle = styled(NavLink)`
+  text-decoration: none;
+  color: var(--color-black);
+  &.active {
+    color: var(--color-main);
+  }
+`;
+
+export default NavigationMenu;

--- a/src/components/mypage/OrderItem.tsx
+++ b/src/components/mypage/OrderItem.tsx
@@ -1,0 +1,51 @@
+import { PropsWithChildren } from "react";
+import styled from "styled-components";
+
+interface OrderItemProps {
+  productImageURL: string;
+}
+
+const OrderItem = ({ productImageURL, children }: PropsWithChildren<OrderItemProps>) => {
+  return (
+    <OrderItemLayer>
+      <ItemWrapper>
+        <ProductImageStyle>
+          <img src={productImageURL} alt="" />
+        </ProductImageStyle>
+        {children}
+      </ItemWrapper>
+    </OrderItemLayer>
+  );
+};
+
+const OrderItemLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-product);
+  height: 21rem;
+  width: 100%;
+  padding: 2.4rem;
+  gap: 2.4rem;
+`;
+
+const ProductImageStyle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: pink;
+  width: 18rem;
+  height: 16rem;
+  overflow: hidden;
+  border-radius: 5px;
+  & > img {
+    height: 100%;
+  }
+`;
+
+export default OrderItem;

--- a/src/components/mypage/OrderItemContentsText.tsx
+++ b/src/components/mypage/OrderItemContentsText.tsx
@@ -1,0 +1,53 @@
+import styled from "styled-components";
+
+interface OrderItemContentsTextProps {
+  textList: string[];
+  subTextList?: string[];
+}
+
+const OrderItemContentsText = ({ textList, subTextList }: OrderItemContentsTextProps) => {
+  return (
+    <OrderItemContentsTextLayer>
+      <TextWrapper>
+        {textList.map((text, idx) => {
+          const newKey = `${idx}OrderItemContentsText_textList`;
+          return <TextStyle key={newKey}>{text}</TextStyle>;
+        })}
+      </TextWrapper>
+      <div>
+        {subTextList?.map((subText, idx) => {
+          const newKey = `${idx}OrderItemContentsText_subTextList`;
+          return <SubTextStyle key={`subText_${newKey}`}>{subText}</SubTextStyle>;
+        })}
+      </div>
+    </OrderItemContentsTextLayer>
+  );
+};
+
+const OrderItemContentsTextLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-right: auto;
+  font-size: 1.8rem;
+  font-weight: bold;
+  min-width: 20rem;
+  gap: 1.4rem;
+  span {
+    display: block;
+    margin-bottom: 0.6rem;
+  }
+`;
+
+const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+`;
+
+const TextStyle = styled.span``;
+const SubTextStyle = styled.span`
+  font-size: 1.6rem;
+  color: var(--color-gray-300);
+`;
+
+export default OrderItemContentsText;

--- a/src/containers/mypageContainer/MypageLayoutContainer.tsx
+++ b/src/containers/mypageContainer/MypageLayoutContainer.tsx
@@ -1,0 +1,55 @@
+import styled from "styled-components";
+import { PropsWithChildren } from "react";
+import NavigationMenu from "@/components/mypage/NavigationMenu";
+import ContainerHeader from "@/components/mypage/ContainerHeader.";
+
+interface MypageLayoutContainerProps {
+  ContentsTitle: string;
+}
+
+const MypageLayoutContainer = ({ ContentsTitle, children }: PropsWithChildren<MypageLayoutContainerProps>) => {
+  return (
+    <MypageLayoutContainerLayer>
+      <MyProfileWrapper></MyProfileWrapper>
+      <MyPageWrapper>
+        <MyPageNavigationWrapper>
+          <NavigationMenu />
+        </MyPageNavigationWrapper>
+        <ContentsWrapper>
+          <ContainerHeader title={ContentsTitle} />
+          {children}
+        </ContentsWrapper>
+      </MyPageWrapper>
+    </MypageLayoutContainerLayer>
+  );
+};
+
+const MypageLayoutContainerLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6rem;
+`;
+const MyProfileWrapper = styled.div`
+  background-color: var(--color-gray-100);
+  display: flex;
+  width: 100%;
+  height: 26rem;
+`;
+
+const MyPageWrapper = styled.div`
+  display: flex;
+  gap: 2.5rem;
+`;
+
+const MyPageNavigationWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export default MypageLayoutContainer;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/mypage-common-component -> dev

## 🔧 작업 내용
- 네비게이션 메뉴 컴포넌트 구현
- 본문의 헤더 컴포넌트 구현
- 주문 아이템 컴포넌트 구현
- 공통 레이아웃 컨테이너 구현

## 📸 스크린샷

## 🔗 관련 이슈
#109 

## 💬 참고사항
