### PR TITLE
feat(mypage/orderList) 주문 내역 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,35 @@
 import "@/App.css";
 import { Outlet } from "react-router-dom";
 import styled from "styled-components";
-import { RecoilRoot } from "recoil";
+import { useSetRecoilState } from "recoil";
+import { useEffect } from "react";
 
+import codeApi from "@/apis/services/code";
+import codeState from "@/recoil/atoms/codeState";
 import Header from "@/components/common/Header";
 import Footer from "@/components/common/Footer";
 
 const App = () => {
+  const setCodeState = useSetRecoilState(codeState);
+  const getCodeData = async () => {
+    try {
+      const { data } = await codeApi.getCode();
+      setCodeState(data.item);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+  useEffect(() => {
+    getCodeData();
+  }, []);
   return (
-    <RecoilRoot>
+    <>
       <Header />
       <ContentsWrapper>
         <Outlet />
       </ContentsWrapper>
       <Footer />
-    </RecoilRoot>
+    </>
   );
 };
 

--- a/src/apis/services/code.ts
+++ b/src/apis/services/code.ts
@@ -1,0 +1,8 @@
+import { publicInstance } from "../instance";
+import { ResponseStateCode } from "../../types/code";
+
+const codeApi = {
+  getCode: () => publicInstance.get<ResponseStateCode>(`/codes`),
+};
+
+export default codeApi;

--- a/src/apis/services/mypage.ts
+++ b/src/apis/services/mypage.ts
@@ -1,0 +1,8 @@
+import { privateInstance } from "../instance";
+import { ResponseDataMyOrderList } from "@/types/myPage";
+
+const myPageApi = {
+  getMyPageOrderList: () => privateInstance.get<ResponseDataMyOrderList>(`/orders`),
+};
+
+export default myPageApi;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -59,7 +59,7 @@ const Header = () => {
   };
   const userControlList = {
     isLogin: [
-      { name: "마이페이지", router: "/mypage", onClick: () => {} },
+      { name: "마이페이지", router: "/mypage/orders", onClick: () => {} },
       { name: "로그아웃", router: "/", onClick: logoutHandleClick },
     ],
     isLogout: [

--- a/src/components/mypage/OrderItem.tsx
+++ b/src/components/mypage/OrderItem.tsx
@@ -18,6 +18,8 @@ const OrderItem = ({ productImageURL, children }: PropsWithChildren<OrderItemPro
   );
 };
 
+export default OrderItem;
+
 const OrderItemLayer = styled.div`
   display: flex;
   flex-direction: column;
@@ -38,7 +40,6 @@ const ProductImageStyle = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: pink;
   width: 18rem;
   height: 16rem;
   overflow: hidden;
@@ -47,5 +48,3 @@ const ProductImageStyle = styled.div`
     height: 100%;
   }
 `;
-
-export default OrderItem;

--- a/src/containers/mypageContainer/MyOrderListContainer.tsx
+++ b/src/containers/mypageContainer/MyOrderListContainer.tsx
@@ -1,0 +1,146 @@
+import styled from "styled-components";
+import { useEffect, useState } from "react";
+import { useRecoilValue } from "recoil";
+import { useNavigate } from "react-router-dom";
+import MypageLayoutContainer from "./MypageLayoutContainer";
+import OrderItem from "@/components/mypage/OrderItem";
+import OrderItemContentsText from "@/components/mypage/OrderItemContentsText";
+import Button from "@/components/common/Button";
+import myPageApi from "@/apis/services/mypage";
+import { MyOrderItem } from "../../types/myPage";
+import GetDate from "@/utils/getDate";
+import truncateString from "@/utils/truncateString";
+
+import codeState from "@/recoil/atoms/codeState";
+
+const MyOrderListContainer = () => {
+  const maxTitleLength = 15;
+  const [orderList, setOrderList] = useState<MyOrderItem[]>([]);
+  const navigator = useNavigate();
+
+  const codeStateData = useRecoilValue(codeState);
+
+  const requestGetMyOrderList = async () => {
+    try {
+      const { data } = await myPageApi.getMyPageOrderList();
+      if (data.ok === 1) {
+        const orderItemList = data.item;
+        setOrderList(() => [...orderItemList]);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const orderItemToThumbnailData = (orderItem: MyOrderItem) => {
+    const getData = new GetDate(orderItem.createdAt);
+    let title = orderItem.products[0].name;
+    if (title.length > maxTitleLength) {
+      if (orderItem.products.length === 1) {
+        title = truncateString({ fullString: orderItem.products[0].name, maxLength: maxTitleLength });
+      } else {
+        title = `${truncateString({ fullString: orderItem.products[0].name, maxLength: maxTitleLength })} 외 ${
+          orderItem.products.length - 1
+        } 개`;
+      }
+    }
+
+    const ShippingCode = orderItem.state || orderItem?.products[0]?.state;
+    return {
+      id: orderItem._id,
+      title: title,
+      date: getData.getDateYearMonthDay(),
+      totalPrice: `${orderItem.cost.total.toLocaleString("ko-KR")} 원`,
+      imgURL: orderItem.products[0].image,
+      shippingState: codeStateData?.flatten[ShippingCode]?.value,
+    };
+  };
+
+  const detailButtonClickHandle = (orderId: string) => {
+    navigator(`/mypage/orders/${orderId}`);
+  };
+
+  useEffect(() => {
+    requestGetMyOrderList();
+  }, []);
+
+  return (
+    <MyOrderListContainerLayer>
+      <MypageLayoutContainer ContentsTitle="주문 내역">
+        <OrderItemListWrapper>
+          {orderList.map((order, idx) => {
+            const mapKey = `${idx}_${order._id}_${order.createdAt}`;
+            const orderThumbnail = orderItemToThumbnailData(order);
+            return (
+              <OrderWrapper key={mapKey} onClick={() => detailButtonClickHandle(`${order._id}`)}>
+                <OrderInfoWrapper>
+                  <span>{orderThumbnail.id}</span>
+                  <span>{orderThumbnail.date}</span>
+                </OrderInfoWrapper>
+                <OrderItem productImageURL={orderThumbnail.imgURL}>
+                  <OrderItemContentsText
+                    textList={[`${orderThumbnail.title}`, `${orderThumbnail.totalPrice}`]}
+                    subTextList={[`${orderThumbnail.date} 주문`]}
+                  />
+                  <ItemRightContentsStyle>
+                    <span>{`${orderThumbnail.shippingState}`}</span>
+                    <DetailButtonWrapper>
+                      <Button value="주문 상세보기" size="md" variant="point" />
+                    </DetailButtonWrapper>
+                  </ItemRightContentsStyle>
+                </OrderItem>
+              </OrderWrapper>
+            );
+          })}
+        </OrderItemListWrapper>
+      </MypageLayoutContainer>
+    </MyOrderListContainerLayer>
+  );
+};
+export default MyOrderListContainer;
+
+const OrderWrapper = styled.div`
+  cursor: pointer;
+`;
+
+const OrderItemListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+`;
+
+const MyOrderListContainerLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6rem;
+`;
+
+const OrderInfoWrapper = styled.div`
+  display: flex;
+  gap: 1rem;
+  font-size: 1.6rem;
+  font-weight: var(--weight-bold);
+  margin-bottom: 1.6rem;
+  :first-child {
+    padding-right: 1rem;
+    border-right: 2px solid var(--color-gray-500);
+  }
+`;
+
+const ItemRightContentsStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 16rem;
+  gap: 1rem;
+  & > span {
+    font-size: 2rem;
+    font-weight: bold;
+  }
+`;
+
+const DetailButtonWrapper = styled.div`
+  height: 5rem;
+  width: 16rem;
+`;

--- a/src/containers/mypageContainer/MypageLayoutContainer.tsx
+++ b/src/containers/mypageContainer/MypageLayoutContainer.tsx
@@ -23,6 +23,7 @@ const MypageLayoutContainer = ({ ContentsTitle, children }: PropsWithChildren<My
     </MypageLayoutContainerLayer>
   );
 };
+export default MypageLayoutContainer;
 
 const MypageLayoutContainerLayer = styled.div`
   display: flex;
@@ -50,6 +51,5 @@ const ContentsWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  gap: 2rem;
 `;
-
-export default MypageLayoutContainer;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "@/index.css";
 import { RouterProvider } from "react-router-dom";
+import { RecoilRoot } from "recoil";
 import router from "./Router";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <RecoilRoot>
+      <RouterProvider router={router} />
+    </RecoilRoot>
   </React.StrictMode>,
 );

--- a/src/pages/MyOrderListPage.tsx
+++ b/src/pages/MyOrderListPage.tsx
@@ -1,5 +1,12 @@
+import MyOrderListContainer from "@/containers/mypageContainer/MyOrderListContainer";
+
 const MyOrderListPage = () => {
-  return <div>주문 목록 페이지</div>;
+  return (
+    <div>
+      주문 목록 페이지
+      <MyOrderListContainer />
+    </div>
+  );
 };
 
 export default MyOrderListPage;

--- a/src/recoil/atoms/codeState.ts
+++ b/src/recoil/atoms/codeState.ts
@@ -1,0 +1,9 @@
+import { atom } from "recoil";
+import { CodeStateType } from "@/types/code";
+
+const codeState = atom<CodeStateType | null>({
+  key: "codeState",
+  default: null,
+});
+
+export default codeState;

--- a/src/types/code.ts
+++ b/src/types/code.ts
@@ -1,0 +1,58 @@
+type Flatten = Record<string, FlattenCode>;
+
+export interface FlattenCode {
+  sort: number;
+  code: string;
+  value: string;
+  parent?: string;
+  depth: number;
+}
+
+export interface CodeStateType {
+  flatten: Flatten;
+}
+
+export interface ResponseStateCode {
+  ok: number;
+  item: CodeStateType;
+}
+
+export interface CodeWithSub {
+  sort: number;
+  code: string;
+  value: string;
+  parent?: string;
+  depth: number;
+  sub?: CodeWithSub[];
+}
+
+export interface ProductCategory {
+  _id: string;
+  title: string;
+  codes: CodeWithSub[];
+}
+
+export interface OrderStateCode {
+  sort: number;
+  code: string;
+  value: string;
+}
+
+export interface OrderState {
+  _id: string;
+  title: string;
+  codes: OrderStateCode[];
+}
+
+export interface MembershipClassCode {
+  sort: number;
+  code: string;
+  value: string;
+  discountRate: number;
+}
+
+export interface MembershipClass {
+  _id: string;
+  title: string;
+  codes: MembershipClassCode[];
+}

--- a/src/types/myPage.ts
+++ b/src/types/myPage.ts
@@ -1,0 +1,56 @@
+export interface ResponseDataMyOrderList {
+  ok: number;
+  item: MyOrderItem[] | [];
+}
+
+export interface MyOrderItem {
+  _id: number;
+  user_id: number;
+  state: string;
+  products: Product[];
+  cost: Cost;
+  address: Address;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Product {
+  _id: number;
+  seller_id: number;
+  state: string;
+  name: string;
+  image: string;
+  quantity: number;
+  price: number;
+  reply_id: number;
+  delivery: Delivery;
+  reply: Reply;
+}
+
+export interface Delivery {
+  company: string;
+  trackingNumber: string;
+  url: string;
+}
+export interface Reply {
+  rating: number;
+  content: string;
+  createdAt: string;
+}
+
+export interface Cost {
+  products: number;
+  shippingFees: number;
+  discount: Discount;
+  total: number;
+}
+
+export interface Discount {
+  products: number;
+  shippingFees: number;
+}
+
+export interface Address {
+  name: string;
+  value: string;
+}

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -1,0 +1,37 @@
+/** 사용법
+const getDataInstance = new GetDate('2023.11.14 13:04:08');
+console.log (getDataInstance.getDateYearMonthDay()) // 2023.11.14
+*/
+
+class GetDate {
+  dateTime: Date | null;
+
+  date = { year: "", month: "", day: "", hours: "", minutes: "", seconds: "" };
+
+  constructor(datetimeString: string) {
+    const [datePart, timePart] = datetimeString.split(" ");
+    const [year, month, day] = datePart.split(".").map((time: string) => parseInt(time, 10));
+    const [hours, minutes, seconds] = timePart.split(":").map((time: string) => parseInt(time, 10));
+    toString();
+    const date = new Date(year, month - 1, day, hours, minutes, seconds);
+    this.dateTime = date;
+    this.#setDate();
+  }
+
+  #setDate() {
+    if (this.dateTime !== null) {
+      this.date.year = `${this.dateTime.getFullYear()}`;
+      this.date.month = `${this.dateTime.getMonth() + 1}`;
+      this.date.day = `${this.dateTime.getDate()}`;
+      this.date.hours = `${this.dateTime.getHours()}`;
+      this.date.minutes = `${this.dateTime.getMinutes()}`;
+      this.date.seconds = `${this.dateTime.getSeconds()}`;
+    }
+  }
+
+  getDateYearMonthDay(): string {
+    return `${this.date.year}.${this.date.month.padStart(2, "0")}.${this.date.day.padStart(2, "0")}`;
+  }
+}
+
+export default GetDate;

--- a/src/utils/truncateString.ts
+++ b/src/utils/truncateString.ts
@@ -1,0 +1,17 @@
+interface TruncateStringProps {
+  fullString: string;
+  maxLength: number;
+}
+
+/**
+ *  긴 문자열을 특정 길이로 제한하고, 초과하는 부분을 "..." (세 개의 점)으로 대체하는 유틸리티 함수
+ * @param param0
+ * @returns
+ */
+const truncateString = ({ fullString, maxLength }: TruncateStringProps): string => {
+  if (fullString.length <= maxLength) {
+    return fullString;
+  }
+  return `${fullString.substring(0, maxLength - 3)}...`;
+};
+export default truncateString;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/mypage-orderList -> dev

## 🔧 작업 내용
- truncateString 함수 추가
제목 썸네일 등을 표시할 때, 제한 길이를 초과하는 경우 ...로 표시하는 유틸리티 함수를 추가하였습니다.
- getDate 클래스 추가
백엔드의 date설정을 Date객체로 변환하고, 사용가자 원하는 메서드를 받을 수 있도록 클래스를 구현하였습니다.
- 코드목록 상태관리 추가
코드목록은 자주 바뀌지 않는 데이터이기 때문에, 최상위 App 컴포넌트에서 한번만 불러오도록 코드를 수정하였습니다.
- 주문 목록 페이지 구현
주문 목록 페이지 컨테이너와 컴포넌트를 구현하였습니다.
- 코드 컨벤션 맞춤
export 부분의 위치를 style 전으로 맞추었습니다.
-  헤더 마이페이지 경로 수정 
NavLink active효과를 위해, 헤더의 마이페이지 경로를 주문내역 경로로 이동하도록 수정하였습니다.

## 📸 스크린샷
<img width="845" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/36308113/d7d71518-6eb1-4bac-a1a0-f773916f062f">


## 🔗 관련 이슈
#111, #109

## 💬 참고사항
관련이슈가 #111 이나, 실수로 #109에 이슈 태그를 달았습니다.