### PR TITLE
feat(/apis): 정렬&필터 작업을 위한 api 함수 생성(#128)

### DIFF
--- a/src/apis/services/products.ts
+++ b/src/apis/services/products.ts
@@ -1,9 +1,59 @@
 import { publicInstance } from "../instance";
 import { ResponseProductsList, ResponseProductInfo } from "@/types/products";
 
+interface SortQueryObject {
+  sortBy: "price" | "createdAt" | "buyQuantity"; // 어떤 기준으로 정렬할지
+  sortOrder: 1 | -1; // 어떤 순서로 정렬할지
+}
+
+interface FilterQueryObject {
+  pack?: string;
+  taste?: string[];
+  teaType?: string[];
+  hashTag?: string[];
+  isDecaf: boolean;
+}
+
+interface RequestSearchProducts {
+  sort?: SortQueryObject;
+  filter?: FilterQueryObject;
+}
+
+const getSortQueryString = (sortQueryObject: SortQueryObject) => {
+  return `sort={"${sortQueryObject.sortBy}": ${sortQueryObject.sortOrder}}`;
+};
+
+const getFilterQueryString = (filterQueryObject: FilterQueryObject) => {
+  const str: string[] = [];
+  const arr = Object.entries(filterQueryObject);
+  arr.forEach((e) => {
+    const [key, value] = e;
+
+    if (typeof value === "object") {
+      // 배열인 경우
+      const valueArr = value.map((el: string) => `"extra.${key}": "${el}"`);
+      str.push(...valueArr);
+    } else if (typeof value === "boolean") {
+      // 불리언인 경우
+      str.push(`"extra.${key}": ${value}`);
+    } else {
+      // 배열도 불리언도 아닌 경우
+      str.push(`"extra.${key}": "${value}"`);
+    }
+  });
+  return `extra={${str.join(", ")}}`;
+};
+
 const productsApi = {
   getAllProducts: () => publicInstance.get<ResponseProductsList>("/products"),
   getProductById: (_id: number) => publicInstance.get<ResponseProductInfo>(`/products/${_id}`),
+  searchProducts: ({ sort, filter }: RequestSearchProducts) => {
+    const sortQueryString = sort ? getSortQueryString(sort) : "";
+    const filterQueryString = filter ? getFilterQueryString(filter) : "";
+    return publicInstance.get<ResponseProductsList>(
+      `/products?${sortQueryString}${sortQueryString && filterQueryString ? "&" : ""}${filterQueryString}`,
+    );
+  },
 };
 
 export default productsApi;


### PR DESCRIPTION
## 📤 반영 브랜치
ex) feat/product-list -> dev

## 🔧 작업 내용
정렬과 필터 작업을 위한 api 함수를 생성했습니다.
모든 데이터를 불러오는 기존 함수(productsApi)에 필터링된 데이터를 불러올 수 있는 함수(searchProducts)를 추가했습니다. 

## 📸 스크린샷

## 🔗 관련 이슈
#128 

## 💬 참고사항
