### PR TITLE
feat(cart): 로그인 여부에 따른 장바구니 금액안내 기능 구현 (#125)

### DIFF
--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -11,6 +11,7 @@ import cartApi from "@/apis/services/cart";
 import { cartState } from "@/recoil/atoms/cartState";
 
 interface CartItemProps {
+  setCartData: React.Dispatch<React.SetStateAction<CartItemType[]>>;
   checkedItems: number[];
   toggleCheckBox: (_id: number) => void;
   handleDeleteItem: (_id: number) => void;
@@ -18,7 +19,7 @@ interface CartItemProps {
   idx: number;
 }
 
-const CartItem = ({ checkedItems, toggleCheckBox, handleDeleteItem, data, idx }: CartItemProps) => {
+const CartItem = ({ setCartData, checkedItems, toggleCheckBox, handleDeleteItem, data, idx }: CartItemProps) => {
   const user = useRecoilValue(loggedInUserState);
   const setCartStorage = useSetRecoilState(cartState);
   const [quantityInput, setQuantityInput] = useState(data.quantity);
@@ -40,14 +41,19 @@ const CartItem = ({ checkedItems, toggleCheckBox, handleDeleteItem, data, idx }:
     }
     if (valueAsNumber > data.product.quantity - data.product.buyQuantity) return;
 
+    const newCartItem = { ...data, quantity: valueAsNumber };
     // 로그인 시
     if (user) {
       updateQuantity(_id, valueAsNumber);
       setQuantityInput(valueAsNumber);
+      setCartData((prev) => {
+        const newCartStorage = [...prev];
+        newCartStorage.splice(idx, 1, newCartItem);
+        return newCartStorage;
+      });
       return;
     }
     // 비로그인 시
-    const newCartItem = { ...data, quantity: valueAsNumber };
     setCartStorage((prev) => {
       const newCartStorage = [...prev];
       newCartStorage.splice(idx, 1, newCartItem);
@@ -59,14 +65,20 @@ const CartItem = ({ checkedItems, toggleCheckBox, handleDeleteItem, data, idx }:
   const handleMinus = (_id: number) => {
     // input상태가 1이라면 return
     if (quantityInput === 1) return;
+
+    const newCartItem = { ...data, quantity: quantityInput - 1 };
     // 로그인 시
     if (user) {
       updateQuantity(_id, quantityInput - 1);
       setQuantityInput(quantityInput - 1);
+      setCartData((prev) => {
+        const newCartStorage = [...prev];
+        newCartStorage.splice(idx, 1, newCartItem);
+        return newCartStorage;
+      });
       return;
     }
     // 비로그인 시
-    const newCartItem = { ...data, quantity: quantityInput - 1 };
     setCartStorage((prev) => {
       const newCartStorage = [...prev];
       newCartStorage.splice(idx, 1, newCartItem);
@@ -78,14 +90,20 @@ const CartItem = ({ checkedItems, toggleCheckBox, handleDeleteItem, data, idx }:
   const handlePlus = (_id: number) => {
     // input상태가 재고와 같다면 return
     if (quantityInput === data.product.quantity - data.product.buyQuantity) return;
+
+    const newCartItem = { ...data, quantity: quantityInput + 1 };
     // 로그인 시
     if (user) {
       updateQuantity(_id, quantityInput + 1);
       setQuantityInput(quantityInput + 1);
+      setCartData((prev) => {
+        const newCartStorage = [...prev];
+        newCartStorage.splice(idx, 1, newCartItem);
+        return newCartStorage;
+      });
       return;
     }
     // 비로그인 시
-    const newCartItem = { ...data, quantity: quantityInput + 1 };
     setCartStorage((prev) => {
       const newCartStorage = [...prev];
       newCartStorage.splice(idx, 1, newCartItem);

--- a/src/containers/cart/CartItemContainer.tsx
+++ b/src/containers/cart/CartItemContainer.tsx
@@ -62,6 +62,7 @@ const CartItemContainer = ({ cartData, setCartData }: CartItemProps) => {
             return (
               <CartItem
                 key={keyIndex}
+                setCartData={setCartData}
                 checkedItems={checkedItems}
                 toggleCheckBox={toggleCheckBox}
                 handleDeleteItem={handleDeleteItem}
@@ -75,6 +76,7 @@ const CartItemContainer = ({ cartData, setCartData }: CartItemProps) => {
             return (
               <CartItem
                 key={keyIndex}
+                setCartData={setCartData}
                 checkedItems={checkedItems}
                 toggleCheckBox={toggleCheckBox}
                 handleDeleteItem={handleDeleteItem}

--- a/src/containers/cart/CartItemListContainer.tsx
+++ b/src/containers/cart/CartItemListContainer.tsx
@@ -9,25 +9,18 @@ import { CartItem, CartItemSummary } from "@/types/cart";
 import loggedInUserState from "@/recoil/atoms/loggedInUserState";
 import cartApi from "@/apis/services/cart";
 
-const CartItemListContainer = () => {
+interface CartItemListContainerProps {
+  cartData: CartItem[]; // DB장바구니 state
+  setCartData: React.Dispatch<React.SetStateAction<CartItem[]>>; // DB장바구니 setState
+}
+
+const CartItemListContainer = ({ cartData, setCartData }: CartItemListContainerProps) => {
   const [isAllChecked, setIsAllChecked] = useState(true);
   const user = useRecoilValue(loggedInUserState);
   // 로컬 장바구니 상태
   const [cartStorage, setCartStorage] = useRecoilState(cartState);
-  // DB 장바구니 상태
-  const [cartData, setCartData] = useState<CartItem[]>([]);
   // 체크박스 상태
   const [checkedItems, setCheckedItems] = useRecoilState(cartCheckedItemState);
-
-  const fetchCartItems = async () => {
-    try {
-      const response = await cartApi.getAllItems();
-      const { item } = response.data;
-      setCartData(item);
-    } catch (error) {
-      console.error(error);
-    }
-  };
 
   const replaceCarts = async (newCart: { products: CartItemSummary[] }) => {
     try {
@@ -50,7 +43,6 @@ const CartItemListContainer = () => {
   };
 
   // [선택삭제]
-  // 로그인 상태 - 백엔드 요청 / 로그아웃 상태 - recoil 상태 변경
   const handleDeleteChecked = () => {
     // 로그인 시
     if (user && cartData) {
@@ -64,11 +56,6 @@ const CartItemListContainer = () => {
     setCartStorage(newCartData);
   };
 
-  // 초기 렌더링 시 로그인 상태면 카트 데이터 GET 요청, checkedItems 배열에 모든 product 추가
-  useEffect(() => {
-    if (user) fetchCartItems();
-  }, []);
-
   useEffect(() => {
     if (user) {
       setCheckedItems([...cartData].map((item) => item._id));
@@ -77,7 +64,9 @@ const CartItemListContainer = () => {
 
   // 체크박스 상태가 바뀌면 모든 아이템이 체크되어있는지 확인
   useEffect(() => {
+    // 로그인 시
     if (user) setIsAllChecked(checkedItems.length > 0 && checkedItems.length === cartData.length);
+    // 비로그인 시
     else setIsAllChecked(checkedItems.length > 0 && checkedItems.length === cartStorage.length);
   }, [checkedItems]);
 

--- a/src/containers/cart/CartPriceContainer.tsx
+++ b/src/containers/cart/CartPriceContainer.tsx
@@ -22,7 +22,9 @@ const CartPriceContainer = ({ cartItems }: { cartItems: CartItemInfo[] }) => {
           <Price priceTitle="총 결제 금액" number={checkedPrice + 0} />
         </div>
       </PriceWrapper>
-      <Button value="구매하기" size="lg" variant="point" />
+      <div>
+        <Button value="구매하기" size="lg" variant="point" />
+      </div>
     </CartPriceContainerLayer>
   );
 };

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,20 +1,39 @@
 import { styled } from "styled-components";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRecoilValue } from "recoil";
 import CartItemListContainer from "@/containers/cart/CartItemListContainer";
 import CartPriceContainer from "@/containers/cart/CartPriceContainer";
 import { CartItem } from "@/types/cart";
+import cartApi from "@/apis/services/cart";
+import loggedInUserState from "@/recoil/atoms/loggedInUserState";
 
 const CartPage = () => {
-  // TODO: CartPrice내에서 로그인 여부 recoil 상태에 따라 처리하고 useState 지우기
-  const [cartItems, setCartItems] = useState<CartItem[]>();
+  const user = useRecoilValue(loggedInUserState);
+  const [cartData, setCartData] = useState<CartItem[]>([]);
+
+  const fetchCartItems = async () => {
+    try {
+      const response = await cartApi.getAllItems();
+      const { item } = response.data;
+      setCartData(item);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // 초기 렌더링 시 로그인 상태면 카트 데이터 GET 요청, checkedItems 배열에 모든 product 추가
+  useEffect(() => {
+    if (user) fetchCartItems();
+  }, []);
+
   return (
-    <>
+    <div>
       <PageTitle>장바구니</PageTitle>
       <Content>
-        <CartItemListContainer />
-        <CartPriceContainer cartItems={cartItems} />
+        <CartItemListContainer cartData={cartData} setCartData={setCartData} />
+        <CartPriceContainer cartData={cartData} />
       </Content>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
- 로그인 여부에 따른 장바구니 금액안내 기능 구현
- 구매하기 버튼 스타일 수정

## 🔗 관련 이슈
#102

## 💬 참고사항
현재는 api 요청시 받는 cost 값을 활용하고 있지 않고, 아이템정보들만으로 계산하여 출력하고 있습니다.