### PR TITLE
feat(orderComplete): 주문완료 페이지 구현 (#139)

### DIFF
--- a/src/pages/OrderCompletePage.tsx
+++ b/src/pages/OrderCompletePage.tsx
@@ -1,5 +1,53 @@
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import Button from "@/components/common/Button";
+
 const OrderCompletePage = () => {
-  return <div>주문완료 페이지</div>;
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      <OrderCompletePageLayer>
+        <p>주문이 완료되었습니다!</p>
+        <ButtonArea>
+          <ButtonWrapper onClick={() => navigate("/")}>
+            <Button value="계속 쇼핑하기" size="md" variant="sub" />
+          </ButtonWrapper>
+          <ButtonWrapper onClick={() => navigate("/mypage/orders")}>
+            <Button value="주문내역 확인하기" size="md" variant="point" />
+          </ButtonWrapper>
+        </ButtonArea>
+      </OrderCompletePageLayer>
+    </div>
+  );
 };
 
 export default OrderCompletePage;
+
+const OrderCompletePageLayer = styled.div`
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 auto;
+
+  p {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 200px;
+    font-size: 2rem;
+    font-weight: var(--weight-bold);
+  }
+`;
+
+const ButtonArea = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+`;
+
+const ButtonWrapper = styled.div`
+  margin: 8px 10px;
+  min-width: 140px;
+`;


### PR DESCRIPTION
## 📤 반영 브랜치
order-complete -> dev

## 🔧 작업 내용
주문완료 페이지 구현
- 계속 쇼핑하기 버튼 생성 (`'/'`으로 이동)
- 주문 내역 확인하기 버튼 생성 (`/mypage/orders`로 이동)

## 📸 스크린샷
<img width="481" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/f2bb73f1-64b1-483a-b871-8d9aa7174802">

## 🔗 관련 이슈

## 💬 참고사항
