### PR TITLE
fix(header): 카테고리 쿼리스트링 코드로 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,23 +5,27 @@ import { useSetRecoilState } from "recoil";
 import { useEffect } from "react";
 
 import codeApi from "@/apis/services/code";
-import codeState from "@/recoil/atoms/codeState";
+import flattenCodeState from "@/recoil/atoms/codeState";
 import Header from "@/components/common/Header";
 import Footer from "@/components/common/Footer";
 
 const App = () => {
-  const setCodeState = useSetRecoilState(codeState);
+  const setFlattenCodeState = useSetRecoilState(flattenCodeState);
+
+  // API를 요청하여 Code를 Set해오는 함수
   const getCodeData = async () => {
     try {
       const { data } = await codeApi.getCode();
-      setCodeState(data.item);
+      setFlattenCodeState(data.item.flatten);
     } catch (error) {
       console.error(error);
     }
   };
+
   useEffect(() => {
     getCodeData();
   }, []);
+
   return (
     <>
       <Header />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,18 +5,20 @@ import { useSetRecoilState } from "recoil";
 import { useEffect } from "react";
 
 import codeApi from "@/apis/services/code";
-import flattenCodeState from "@/recoil/atoms/codeState";
+import { flattenCodeState, nestedCodeState } from "@/recoil/atoms/codeState";
 import Header from "@/components/common/Header";
 import Footer from "@/components/common/Footer";
 
 const App = () => {
   const setFlattenCodeState = useSetRecoilState(flattenCodeState);
+  const setNestedCodeState = useSetRecoilState(nestedCodeState);
 
   // API를 요청하여 Code를 Set해오는 함수
   const getCodeData = async () => {
     try {
       const { data } = await codeApi.getCode();
       setFlattenCodeState(data.item.flatten);
+      setNestedCodeState(data.item.nested);
     } catch (error) {
       console.error(error);
     }

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,6 +9,8 @@ import { getUserTypeState } from "@/recoil/selectors/loggedInUserSelector";
 // constants
 import { AUTH_TOKEN_KEY } from "@/constants/api";
 import { MANAGE_TYPE } from "@/constants/user";
+import { FlattenData } from "@/types/code";
+import getProductCategoryValueByCode from "@/recoil/selectors/codeSelector";
 
 interface CategoryLinkProps {
   $isActive?: boolean;
@@ -25,6 +27,8 @@ const Header = () => {
   const location = useLocation();
 
   useEffect(() => {
+    // const code = myCode("티백");
+
     const authToken = localStorage.getItem(AUTH_TOKEN_KEY);
     if (authToken) {
       setIsLogin(true);
@@ -45,13 +49,40 @@ const Header = () => {
     setIsLogin(false);
   };
 
+  const categoryCode = {
+    티백: useRecoilValue(getProductCategoryValueByCode({ oneDepthValue: "pack", twoDepthValue: "티백" })),
+    잎차: useRecoilValue(getProductCategoryValueByCode({ oneDepthValue: "pack", twoDepthValue: "잎차" })),
+    분말: useRecoilValue(getProductCategoryValueByCode({ oneDepthValue: "pack", twoDepthValue: "분말" })),
+    "음료/원액": useRecoilValue(getProductCategoryValueByCode({ oneDepthValue: "pack", twoDepthValue: "음료-원액" })),
+  };
+
   const categoryList = {
     common: [
       { name: "모든 상품", router: "/products", location: "/products", categoryParams: null },
-      { name: "티백", router: "/products?pack=teabags", location: "/products", categoryParams: "teabags" },
-      { name: "잎차", router: "/products?pack=tealeaves", location: "/products", categoryParams: "tealeaves" },
-      { name: "분말", router: "/products?pack=powders", location: "/products", categoryParams: "powders" },
-      { name: "음료/원액", router: "/products?pack=liquids", location: "/products", categoryParams: "liquids" },
+      {
+        name: "티백",
+        router: `/products?pack=${categoryCode.티백}`,
+        location: "/products",
+        categoryParams: categoryCode.티백,
+      },
+      {
+        name: "잎차",
+        router: `/products?pack=${categoryCode.잎차}`,
+        location: "/products",
+        categoryParams: categoryCode.잎차,
+      },
+      {
+        name: "분말",
+        router: `/products?pack=${categoryCode.분말}`,
+        location: "/products",
+        categoryParams: categoryCode.분말,
+      },
+      {
+        name: "음료/원액",
+        router: `/products?pack=${categoryCode["음료/원액"]}`,
+        location: "/products",
+        categoryParams: categoryCode["음료/원액"],
+      },
     ],
     admin: [
       { name: "관리자페이지", router: "/manage", isPublic: false, location: "/manage" }, // TODO: api 개발 완료 후 라우터 수정

--- a/src/containers/mypageContainer/MyOrderListContainer.tsx
+++ b/src/containers/mypageContainer/MyOrderListContainer.tsx
@@ -11,7 +11,7 @@ import { MyOrderItem } from "../../types/myPage";
 import GetDate from "@/utils/getDate";
 import truncateString from "@/utils/truncateString";
 
-import flattenCodeState from "@/recoil/atoms/codeState";
+import { flattenCodeState } from "@/recoil/atoms/codeState";
 import { FlattenData } from "@/types/code";
 
 const MyOrderListContainer = () => {

--- a/src/containers/mypageContainer/MyOrderListContainer.tsx
+++ b/src/containers/mypageContainer/MyOrderListContainer.tsx
@@ -11,14 +11,15 @@ import { MyOrderItem } from "../../types/myPage";
 import GetDate from "@/utils/getDate";
 import truncateString from "@/utils/truncateString";
 
-import codeState from "@/recoil/atoms/codeState";
+import flattenCodeState from "@/recoil/atoms/codeState";
+import { FlattenData } from "@/types/code";
 
 const MyOrderListContainer = () => {
   const maxTitleLength = 15;
   const [orderList, setOrderList] = useState<MyOrderItem[]>([]);
   const navigator = useNavigate();
 
-  const codeStateData = useRecoilValue(codeState);
+  const flattenCodeDataState: FlattenData = useRecoilValue(flattenCodeState);
 
   const requestGetMyOrderList = async () => {
     try {
@@ -46,13 +47,15 @@ const MyOrderListContainer = () => {
     }
 
     const ShippingCode = orderItem.state || orderItem?.products[0]?.state;
+    const shippingState = flattenCodeDataState[ShippingCode]?.value;
+
     return {
       id: orderItem._id,
       title: title,
       date: getData.getDateYearMonthDay(),
       totalPrice: `${orderItem.cost.total.toLocaleString("ko-KR")} 원`,
       imgURL: orderItem.products[0].image,
-      shippingState: codeStateData?.flatten[ShippingCode]?.value,
+      shippingState: shippingState,
     };
   };
 

--- a/src/recoil/atoms/codeState.ts
+++ b/src/recoil/atoms/codeState.ts
@@ -1,9 +1,9 @@
 import { atom } from "recoil";
-import { CodeStateType } from "@/types/code";
+import { FlattenData } from "@/types/code";
 
-const codeState = atom<CodeStateType | null>({
-  key: "codeState",
-  default: null,
+const flattenCodeState = atom<FlattenData | {}>({
+  key: "flattenCodeState",
+  default: {},
 });
 
-export default codeState;
+export default flattenCodeState;

--- a/src/recoil/atoms/codeState.ts
+++ b/src/recoil/atoms/codeState.ts
@@ -1,9 +1,12 @@
 import { atom } from "recoil";
-import { FlattenData } from "@/types/code";
+import { FlattenData, NestedData } from "@/types/code";
 
-const flattenCodeState = atom<FlattenData | {}>({
+export const flattenCodeState = atom<FlattenData>({
   key: "flattenCodeState",
   default: {},
 });
 
-export default flattenCodeState;
+export const nestedCodeState = atom<NestedData | null>({
+  key: "nestedCodeState",
+  default: null,
+});

--- a/src/recoil/selectors/codeSelector.ts
+++ b/src/recoil/selectors/codeSelector.ts
@@ -1,0 +1,34 @@
+import { selectorFamily } from "recoil";
+import { nestedCodeState } from "../atoms/codeState";
+import { CodeWithSub } from "@/types/code";
+
+/** 사용 코드 예)
+ *  useRecoilValue(getProductCategoryValueByCode({ oneDepthValue: "pack", twoDepthValue: "티백" })),
+ */
+type ValueByCode = Record<string, CodeWithSub>;
+const getProductCategoryValueByCode = selectorFamily<
+  ValueByCode | {},
+  { oneDepthValue: string; twoDepthValue?: string }
+>({
+  key: "getValueByCode",
+  get:
+    ({ oneDepthValue, twoDepthValue }) =>
+    ({ get }) => {
+      const codeInfo = get(nestedCodeState);
+      if (codeInfo) {
+        const oneDepthFound = codeInfo.productCategory.codes.find((codeItem) => {
+          return codeItem.value === oneDepthValue;
+        });
+        if (twoDepthValue && oneDepthFound?.sub) {
+          const twoDepthFound: CodeWithSub | undefined = oneDepthFound.sub.find((codeItem) => {
+            return codeItem.value === twoDepthValue;
+          });
+          return twoDepthFound?.code || "";
+        }
+        return oneDepthFound?.code || "";
+      }
+      return {};
+    },
+});
+
+export default getProductCategoryValueByCode;

--- a/src/recoil/selectors/loggedInUserSelector.ts
+++ b/src/recoil/selectors/loggedInUserSelector.ts
@@ -1,5 +1,5 @@
 import { selector } from "recoil";
-import loggedInUserState from "../atoms/loggedInUserState";
+import loggedInUserState from "@/recoil/atoms/loggedInUserState";
 
 export const getUserIdState = selector({
   key: "userIdState",

--- a/src/types/code.ts
+++ b/src/types/code.ts
@@ -1,20 +1,28 @@
-type Flatten = Record<string, FlattenCode>;
-
-export interface FlattenCode {
-  sort: number;
-  code: string;
-  value: string;
-  parent?: string;
-  depth: number;
-}
-
-export interface CodeStateType {
-  flatten: Flatten;
-}
-
 export interface ResponseStateCode {
   ok: number;
   item: CodeStateType;
+}
+
+export interface CodeStateType {
+  flatten: FlattenData;
+  nested: NestedData;
+}
+
+export type FlattenData = Record<string, FlattenDataItem>;
+
+export interface FlattenDataItem {
+  sort: number;
+  code: string;
+  value: string;
+  depth?: number;
+  parent?: string;
+  discountRate?: number;
+}
+
+export interface NestedData {
+  productCategory: ProductCategory;
+  orderState: OrderState;
+  membershipClass: MembershipClass;
 }
 
 export interface CodeWithSub {


### PR DESCRIPTION
## 📤 반영 브랜치
feat/header-category-path -> dev

## 🔧 작업 내용
- 타입 명칭 수정
nested 구조 사용을 고려한 기존 code 명칭을 수정하였습니다.
기존 코드 관련된 부분도 수정하였습니다.
- `getProductCategoryValueByCode` 코드 selector추가
   value를 기준으로 code를 가져오는 Selector를 추가하였습니다.
- 카테고리 쿼리스트링 코드로 수정
헤더에 카테고리 버튼 클릭 시 쿼리스트링이 코드가 되게 수정하였습니다.
getProductCategoryValueByCode Selector를 사용하였습니다.

## 📸 스크린샷

## 🔗 관련 이슈
#121

## 💬 참고사항
