### PR TITLE
feat(OrderDetail): 주문 상세페이지 구현 (#147)

### DIFF
--- a/src/components/mypage/OrderDetailInfo.tsx
+++ b/src/components/mypage/OrderDetailInfo.tsx
@@ -1,0 +1,82 @@
+import styled from "styled-components";
+import { useRecoilValue } from "recoil";
+import ContainerHeader from "./ContainerHeader.";
+import { MyOrderItem } from "@/types/myPage";
+import { getUserNameState } from "../../recoil/selectors/loggedInUserSelector";
+import getPriceFormat from "@/utils/getPriceFormat";
+
+interface OrderDetailInfoProps {
+  orderData?: MyOrderItem;
+}
+
+const OrderDetailInfo = ({ orderData }: OrderDetailInfoProps) => {
+  const userName = useRecoilValue(getUserNameState);
+  const infoList = [
+    { title: "주문자 정보", value: userName },
+    { title: "배송지", value: orderData?.address?.name },
+    { title: "배송지 주소", value: orderData?.address?.value },
+    { title: "상품 금액", value: getPriceFormat({ price: orderData?.cost.products }) },
+    { title: "배송비", value: getPriceFormat({ price: orderData?.cost.shippingFees }) },
+    {
+      title: "상품 할인 금액",
+      value: `- ${getPriceFormat({ price: orderData?.cost.discount.products })}	`,
+    },
+    { title: "배송 할인 금액", value: `- ${getPriceFormat({ price: orderData?.cost.discount.shippingFees })}` },
+  ];
+
+  return (
+    <OrderDetailInfoLayer>
+      <ContainerHeader title="주문 정보" />
+      <InfoListWrapper>
+        {infoList.map((infoData, idx) => {
+          const infoWrapperKey = `OrderDetailInfo_InfoWrapper_${idx}`;
+          return (
+            <InfoDataStyle key={infoWrapperKey}>
+              <InfoTitleStyle>{infoData.title}</InfoTitleStyle>
+              <InfoValueStyle>{infoData.value}</InfoValueStyle>
+            </InfoDataStyle>
+          );
+        })}
+      </InfoListWrapper>
+      <TotalCostWrapper>
+        <span>총 {getPriceFormat({ price: orderData?.cost?.total })}</span>
+      </TotalCostWrapper>
+    </OrderDetailInfoLayer>
+  );
+};
+
+export default OrderDetailInfo;
+
+const OrderDetailInfoLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+const InfoListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+`;
+const InfoDataStyle = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+const InfoTitleStyle = styled.span`
+  font-weight: var(--weight-bold);
+`;
+const InfoValueStyle = styled.span`
+  font-weight: var(--weight-regular);
+`;
+const TotalCostWrapper = styled.div`
+  width: 100%;
+  border-top: 1px solid var(--color-black);
+  display: flex;
+  justify-content: end;
+  padding-top: 2rem;
+
+  span {
+    font-weight: var(--weight-bold);
+    font-size: 2.4rem;
+  }
+`;

--- a/src/containers/mypageContainer/MyOrderDetailContainer.tsx
+++ b/src/containers/mypageContainer/MyOrderDetailContainer.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from "react";
+import styled from "styled-components";
+import { useParams, useNavigate } from "react-router-dom";
+
+import MypageLayoutContainer from "@/containers/mypageContainer/MypageLayoutContainer";
+import { MyOrderItem } from "@/types/myPage";
+import myPageApi from "@/apis/services/mypage";
+import OrderItem from "@/components/mypage/OrderItem";
+import OrderItemContentsText from "@/components/mypage/OrderItemContentsText";
+import Button from "@/components/common/Button";
+import OrderDetailInfo from "@/components/mypage/OrderDetailInfo";
+import getPriceFormat from "@/utils/getPriceFormat";
+
+const MyOrderDetailContainer = () => {
+  const [orderDetail, setOrderDetail] = useState<MyOrderItem>();
+  const navigator = useNavigate();
+  const { id } = useParams();
+
+  const requestGetMyOrderList = async () => {
+    try {
+      const { data } = await myPageApi.getMyPageOrderList();
+      if (data.ok === 1) {
+        const orderItemList = data.item;
+        const orderItem = orderItemList.find((item) => `${item._id}` === `${id}`);
+        setOrderDetail(orderItem);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const reviewButtonHandleClick = () => {
+    // TODO: 리뷰 작성 페이지 구현
+    navigator(`/mypage/reviews`);
+  };
+
+  useEffect(() => {
+    requestGetMyOrderList();
+  }, []);
+  return (
+    <MypageLayoutContainer ContentsTitle="주문 상세 페이지">
+      <MyOrderDetailContainerLayer>
+        <div>
+          {orderDetail?.products.map((product, idx) => {
+            const orderItemKey = `MypageLayoutContainer_${product._id}${idx}`;
+            return (
+              <OrderItem key={orderItemKey} productImageURL={product.image}>
+                <OrderItemContentsText
+                  textList={[product.name, getPriceFormat({ price: product.price })]}
+                ></OrderItemContentsText>
+                <ReviewButtonWrapper onClick={reviewButtonHandleClick}>
+                  <Button value="리뷰 작성" size="md" variant="point" />
+                </ReviewButtonWrapper>
+              </OrderItem>
+            );
+          })}
+        </div>
+        <OrderDetailInfo orderData={orderDetail} />
+      </MyOrderDetailContainerLayer>
+    </MypageLayoutContainer>
+  );
+};
+
+export default MyOrderDetailContainer;
+
+const MyOrderDetailContainerLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6rem;
+`;
+const ReviewButtonWrapper = styled.div`
+  height: 5rem;
+  width: 16rem;
+`;

--- a/src/containers/mypageContainer/MyOrderListContainer.tsx
+++ b/src/containers/mypageContainer/MyOrderListContainer.tsx
@@ -13,6 +13,7 @@ import truncateString from "@/utils/truncateString";
 
 import { flattenCodeState } from "@/recoil/atoms/codeState";
 import { FlattenData } from "@/types/code";
+import getPriceFormat from "@/utils/getPriceFormat";
 
 const MyOrderListContainer = () => {
   const maxTitleLength = 15;
@@ -53,7 +54,7 @@ const MyOrderListContainer = () => {
       id: orderItem._id,
       title: title,
       date: getData.getDateYearMonthDay(),
-      totalPrice: `${orderItem.cost.total.toLocaleString("ko-KR")} 원`,
+      totalPrice: getPriceFormat({ price: orderItem.cost.total }),
       imgURL: orderItem.products[0].image,
       shippingState: shippingState,
     };

--- a/src/pages/MyOrderDetailPage.tsx
+++ b/src/pages/MyOrderDetailPage.tsx
@@ -1,5 +1,7 @@
+import MyOrderDetailContainer from "@/containers/mypageContainer/MyOrderDetailContainer";
+
 const MyOrderDetailPage = () => {
-  return <div>주문 상세 페이지</div>;
+  return <MyOrderDetailContainer />;
 };
 
 export default MyOrderDetailPage;

--- a/src/pages/MyOrderListPage.tsx
+++ b/src/pages/MyOrderListPage.tsx
@@ -1,12 +1,7 @@
 import MyOrderListContainer from "@/containers/mypageContainer/MyOrderListContainer";
 
 const MyOrderListPage = () => {
-  return (
-    <div>
-      주문 목록 페이지
-      <MyOrderListContainer />
-    </div>
-  );
+  return <MyOrderListContainer />;
 };
 
 export default MyOrderListPage;

--- a/src/recoil/selectors/loggedInUserSelector.ts
+++ b/src/recoil/selectors/loggedInUserSelector.ts
@@ -1,4 +1,4 @@
-import { selector } from "recoil";
+import { selector, selectorFamily } from "recoil";
 import loggedInUserState from "@/recoil/atoms/loggedInUserState";
 
 export const getUserIdState = selector({
@@ -20,5 +20,16 @@ export const getUserTypeState = selector({
       return null;
     }
     return userInfo.type;
+  },
+});
+
+export const getUserNameState = selector({
+  key: "userNametate",
+  get: ({ get }) => {
+    const userInfo = get(loggedInUserState);
+    if (userInfo === null) {
+      return null;
+    }
+    return userInfo.name;
   },
 });

--- a/src/utils/getPriceFormat.ts
+++ b/src/utils/getPriceFormat.ts
@@ -1,0 +1,10 @@
+interface GetPriceFormatProps {
+  price: string | number | undefined;
+  locales?: "ko-KR";
+  unit?: "원";
+}
+const getPriceFormat = ({ price = 0, locales = "ko-KR", unit = "원" }: GetPriceFormatProps) => {
+  return `${price.toLocaleString(locales)} ${unit}`;
+};
+
+export default getPriceFormat;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/mypage-orderdetail -> dev

## 🔧 작업 내용
- 주문 상세페이지 구현
- 유틸리티 함수인 가격 포멧팅 함수 구현
- 사용자 이름 가져오는 selector 추가

## 📸 스크린샷
![image](https://github.com/Eurachacha/hanmogeum/assets/36308113/37f45e41-39a8-4436-9aac-e8f8725daaa5)


## 🔗 관련 이슈
#147

## 💬 참고사항
