### PR TITLE
feat(cart): [로그인] 재고부족시 재고만큼 수량 update (#154)

### DIFF
--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -26,7 +26,7 @@ const isLocalData = (object: CartStorageItem | CartItemType) => {
 const CartItem = ({ setCartData, checkedItems, toggleCheckBox, handleDeleteItem, data, idx }: CartItemProps) => {
   const user = useRecoilValue(loggedInUserState);
   const setCartStorage = useSetRecoilState(cartState);
-  const [quantityInput, setQuantityInput] = useState(data.quantity);
+  const [quantityInput, setQuantityInput] = useState(0);
   const [cartItemPrice, setCartItemPrice] = useState(data.product.price * quantityInput);
 
   const updateQuantity = (_id: number, newQuantity: number) => {
@@ -125,7 +125,14 @@ const CartItem = ({ setCartData, checkedItems, toggleCheckBox, handleDeleteItem,
   };
 
   useEffect(() => {
-    setQuantityInput(data.quantity);
+    if (user) {
+      const cartData = data as CartItemType;
+      if (data.quantity > cartData.product.quantity - cartData.product.buyQuantity) {
+        setQuantityInput(cartData.product.quantity - cartData.product.buyQuantity);
+        updateQuantity((data as CartItemType)._id, cartData.product.quantity - cartData.product.buyQuantity);
+      } else setQuantityInput(data.quantity);
+    } else setQuantityInput(data.quantity);
+    // TODO: [비로그인] dryRun 에러 형태 확정 시 작업
   }, [data]);
 
   useEffect(() => {


### PR DESCRIPTION
## 📤 반영 브랜치
ex) feat/cart -> dev

## 🔧 작업 내용
로그인상태로 초기 접속시 재고가 부족하면 재고만큼 input에 반영하고 수량 수정 요청을 하도록 구현했습니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
