### PR TITLE
feat(cart): 수량조절시 0 미만 제한 (#186)

### DIFF
--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -71,7 +71,7 @@ const CartItem = ({ setCartData, checkedItems, toggleCheckBox, handleDeleteItem,
 
   const handleMinus = (_id: number) => {
     // input상태가 1이라면 return
-    if (quantityInput === 1) return;
+    if (quantityInput <= 1) return;
 
     // 로그인 시 (data가 DB데이터인 경우)
     if (user && !isLocalData(data)) {
@@ -159,7 +159,7 @@ const CartItem = ({ setCartData, checkedItems, toggleCheckBox, handleDeleteItem,
               </CounterButton>
               <QuantityWrapper
                 type="number"
-                min={1}
+                min={0}
                 max={
                   user ? (data as CartItemType).product.quantity - (data as CartItemType).product.buyQuantity : 10
                 } /* TODO: dryRun 에러 형태 확정시 반영 */


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
장바구니 수량 조절 시 재고가 0개인 경우 0미만으로 내려가는 버그를 수정했습니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
