### PR TITLE
fix(header): 헤더 장바구니 개수 출력 (#178)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -26,7 +26,7 @@ const Header = () => {
   const [searchParams] = useSearchParams();
   const userType = useRecoilValue(getUserTypeState);
   const [user, setUser] = useRecoilState(loggedInUserState);
-  const setCartStorage = useSetRecoilState(cartState);
+  const [cartStorage, setCartStorage] = useRecoilState(cartState);
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -38,7 +38,7 @@ const Header = () => {
     if (authToken) {
       setIsLogin(true);
       // TODO: 로그인한 사용자의 장바구니를 불러온다.
-      setCartCount(0);
+      setCartCount(cartStorage.length);
       if (MANAGE_TYPE.some((manageType) => userType === manageType)) {
         setIsManager(true);
       }


### PR DESCRIPTION
## 📤 반영 브랜치
feat/header-cart-counting -> dev

## 🔧 작업 내용
- recoil에서 관리중인 cartState 배열의 길이에 따라 장바구니의 개 수 가 표시되도록 수정하였습니다.
## 📸 스크린샷

## 🔗 관련 이슈
#178

## 💬 참고사항
