### PR TITLE
fix(OrderDetailInfo): 주문자 정보 수정 (#176)

### DIFF
--- a/src/components/mypage/OrderDetailInfo.tsx
+++ b/src/components/mypage/OrderDetailInfo.tsx
@@ -2,19 +2,28 @@ import styled from "styled-components";
 import { useRecoilValue } from "recoil";
 import ContainerHeader from "./ContainerHeader.";
 import { MyOrderItem } from "@/types/myPage";
-import { getUserNameState } from "../../recoil/selectors/loggedInUserSelector";
 import getPriceFormat from "@/utils/getPriceFormat";
+import loggedInUserState from "@/recoil/atoms/loggedInUserState";
+import autoHyphenPhoneNumber from "../../utils/autoHyphenPhoneNumber";
 
 interface OrderDetailInfoProps {
   orderData?: MyOrderItem;
 }
 
 const OrderDetailInfo = ({ orderData }: OrderDetailInfoProps) => {
-  const userName = useRecoilValue(getUserNameState);
+  const currentUserInfo = useRecoilValue(loggedInUserState);
   const infoList = [
-    { title: "주문자 정보", value: userName },
-    { title: "배송지", value: orderData?.address?.name },
-    { title: "배송지 주소", value: orderData?.address?.value },
+    { title: "주문자 정보", value: currentUserInfo?.name },
+    { title: "주문자 이메일", value: currentUserInfo?.email },
+    { title: "주문자 전화번호", value: autoHyphenPhoneNumber(currentUserInfo?.phone || "") },
+
+    { title: "받는분 배송지", value: orderData?.shippingInfo?.name },
+    { title: "받는분 연락처", value: autoHyphenPhoneNumber(orderData?.shippingInfo?.phone || "") },
+    {
+      title: "받는분 배송지 주소",
+      value: `${orderData?.shippingInfo?.address.value} ${orderData?.shippingInfo?.address?.detailValue || ""}`,
+    },
+
     { title: "상품 금액", value: getPriceFormat({ price: orderData?.cost.products }) },
     { title: "배송비", value: getPriceFormat({ price: orderData?.cost.shippingFees }) },
     {

--- a/src/containers/mypageContainer/MyOrderListContainer.tsx
+++ b/src/containers/mypageContainer/MyOrderListContainer.tsx
@@ -36,8 +36,8 @@ const MyOrderListContainer = () => {
 
   const orderItemToThumbnailData = (orderItem: MyOrderItem) => {
     const getData = new GetDate(orderItem.createdAt);
-    let title = orderItem.products[0].name;
-    if (title.length > maxTitleLength) {
+    let title = orderItem?.products[0]?.name;
+    if (title?.length > maxTitleLength) {
       if (orderItem.products.length === 1) {
         title = truncateString({ fullString: orderItem.products[0].name, maxLength: maxTitleLength });
       } else {
@@ -55,7 +55,7 @@ const MyOrderListContainer = () => {
       title: title,
       date: getData.getDateYearMonthDay(),
       totalPrice: getPriceFormat({ price: orderItem.cost.total }),
-      imgURL: orderItem.products[0].image,
+      imgURL: orderItem?.products[0]?.image,
       shippingState: shippingState,
     };
   };

--- a/src/types/myPage.ts
+++ b/src/types/myPage.ts
@@ -12,9 +12,21 @@ export interface MyOrderItem {
   state: string;
   products: Product[];
   cost: Cost;
-  address: Address;
+  shippingInfo: ShippingInfo;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface ShippingInfo {
+  name: string;
+  phone: string;
+  address: ShippingAddress;
+}
+
+export interface ShippingAddress {
+  name?: string;
+  value?: string;
+  detailValue?: string;
 }
 
 export interface Product {
@@ -52,11 +64,6 @@ export interface Cost {
 export interface Discount {
   products: number;
   shippingFees: number;
-}
-
-export interface Address {
-  name: string;
-  value: string;
 }
 
 // 마이페이지 > 내정보 수정


### PR DESCRIPTION
## 📤 반영 브랜치
feat/mypage-OrderDetailInfo-fix -> dev

## 🔧 작업 내용
- 구매하기 페이지의 구매 정보와, 구매 내역에서 보여주는 구매자 정보가 맞지 않아 수정하였습니다.

## 📸 스크린샷

## 🔗 관련 이슈
#176

## 💬 참고사항
