### PR TITLE
chore(Modal): 줄바꿈, 강조텍스트 구현 (#220)

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -20,21 +20,27 @@ const Modal = ({ isOpen, iconRequired = false, targetString, message, children }
         )}
         {targetString && (
           <BoldText>
-            {targetString.split("\n").map((str) => (
-              <>
-                {str}
-                <br />
-              </>
-            ))}
+            {targetString.split("\n").map((str, idx) => {
+              const keyIndex = idx.toString() + str;
+              return (
+                <span key={keyIndex}>
+                  {str}
+                  <br />
+                </span>
+              );
+            })}
           </BoldText>
         )}
         <MessageWrapper>
-          {message.split("\n").map((str) => (
-            <>
-              {str}
-              <br />
-            </>
-          ))}
+          {message.split("\n").map((str, idx) => {
+            const keyIndex = idx.toString() + str;
+            return (
+              <span key={keyIndex}>
+                {str}
+                <br />
+              </span>
+            );
+          })}
         </MessageWrapper>
         <ButtonArea>{children}</ButtonArea>
       </ModalContainer>
@@ -81,7 +87,7 @@ const IconWrapper = styled.div`
   margin-bottom: 1rem;
 `;
 
-const BoldText = styled.p`
+const BoldText = styled.div`
   font-weight: var(--weight-bold);
 `;
 

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -5,10 +5,11 @@ import CircleCheckIcon from "@/assets/icons/circleCheck.svg?react";
 interface ModalProps {
   isOpen: boolean;
   iconRequired?: boolean;
+  targetString?: string;
   message: string;
 }
 
-const Modal = ({ isOpen, iconRequired = false, message, children }: PropsWithChildren<ModalProps>) => {
+const Modal = ({ isOpen, iconRequired = false, targetString, message, children }: PropsWithChildren<ModalProps>) => {
   return (
     <WholeContainer $isOpen={isOpen}>
       <ModalContainer>
@@ -17,7 +18,24 @@ const Modal = ({ isOpen, iconRequired = false, message, children }: PropsWithChi
             <CircleCheckIcon />
           </IconWrapper>
         )}
-        <MessageWrapper>{message}</MessageWrapper>
+        {targetString && (
+          <BoldText>
+            {targetString.split("\n").map((str) => (
+              <>
+                {str}
+                <br />
+              </>
+            ))}
+          </BoldText>
+        )}
+        <MessageWrapper>
+          {message.split("\n").map((str) => (
+            <>
+              {str}
+              <br />
+            </>
+          ))}
+        </MessageWrapper>
         <ButtonArea>{children}</ButtonArea>
       </ModalContainer>
     </WholeContainer>
@@ -61,6 +79,10 @@ const ModalContainer = styled.div`
 const IconWrapper = styled.div`
   color: var(--color-sub-500);
   margin-bottom: 1rem;
+`;
+
+const BoldText = styled.p`
+  font-weight: var(--weight-bold);
 `;
 
 const MessageWrapper = styled.p`


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-detail -> dev

## 🔧 작업 내용
- `\n`문자열로 split후 map함수를 사용해 줄바꿈텍스트를 넣을 수 있습니다.
- targetString optional prop에 전달되는 문자열은 강조처리됩니다.

## 📸 스크린샷
<img width="344" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/2794f411-43a0-44e5-afaf-cb0fcb59cf28">

## 🔗 관련 이슈

## 💬 참고사항
