### PR TITLE
feat(ProductList): 상품목록 카테고리에서 pack 제외(#138)

### DIFF
--- a/src/components/product/productlist/CategoryList.tsx
+++ b/src/components/product/productlist/CategoryList.tsx
@@ -5,63 +5,73 @@ import ToggleDefault from "@/assets/icons/toggleDefault.svg?react";
 import ToggleActive from "@/assets/icons/toggleActive.svg?react";
 import CategoryButtonList from "./CategoryButtonList";
 import { nestedCodeState } from "@/recoil/atoms/codeState";
+import { CATEGORY_CONTENT, CATEGORY_TITLE } from "@/constants/category";
+import useQueryParams from "@/hooks/useQueryParams";
 
 const CategoryList = () => {
   const [codes] = useRecoilState(nestedCodeState);
 
-  const [toggle, setToggle] = useState(false);
+  const [isDecaf, setIsDecaf] = useState(false);
 
-  const handleToggle = () => {
-    setToggle(!toggle);
+  const handleIsDecaf = () => {
+    setIsDecaf(!isDecaf);
+    toggleFilter((!isDecaf).toString());
   };
 
+  const { toggleFilter } = useQueryParams("isDecaf");
   return (
-    <ProductListCategoryLayer>
-      <StyledTitle $fontSize="3.6rem" $fontWeight="var(--weight-bold)" $margin="0 0 40px 0">
+    <CategoryListLayer>
+      <StyledTitle $fontSize="3.6rem" $fontWeight="var(--weight-bold)" $margin="0 0 60px 0">
         전체상품
       </StyledTitle>
 
-      <ul>
-        <ProductListCategoryWrapper>
-          <StyledTitleDisplayContent>
-            <StyledTitle $fontSize="1.6rem" $fontWeight="var(--weight-semibold)">
-              디카페인
-            </StyledTitle>
-            <StyledToggleButton onClick={handleToggle}>
-              {toggle ? <ToggleActive /> : <ToggleDefault />}
-            </StyledToggleButton>
-          </StyledTitleDisplayContent>
-        </ProductListCategoryWrapper>
+      {codes?.productCategory.codes.map(
+        (item, index) =>
+          index > 0 &&
+          (item.sub ? (
+            <CategoryListWrapper>
+              <StyledTitleDisplay>
+                <StyledTitle $fontSize="1.6rem" $fontWeight="var(--weight-semibold)">
+                  {CATEGORY_TITLE[item.value]}
+                </StyledTitle>
+                <StyledSubTitle>{CATEGORY_CONTENT[item.value]}</StyledSubTitle>
+              </StyledTitleDisplay>
 
-        {/* TODO: sort로 지정한 map의 key를 변수로 수정 */}
+              <StyledButtonList>
+                <CategoryButtonList subCategory={item.sub} value={item.value} />
+              </StyledButtonList>
+            </CategoryListWrapper>
+          ) : (
+            <CategoryListWrapper>
+              <StyledDecafTitleDisplay>
+                <StyledTitle $fontSize="1.6rem" $fontWeight="var(--weight-semibold)">
+                  디카페인
+                </StyledTitle>
 
-        {codes?.productCategory.codes.map((code) => (
-          <ProductListCategoryWrapper key={code.sort}>
-            <StyledTitleDisplay>
-              <StyledTitle $fontSize="1.6rem" $fontWeight="var(--weight-semibold)">
-                {code.value}
-              </StyledTitle>
-              <StyledSubTitle>좋아하는 맛을 선택해보세요.</StyledSubTitle>
-            </StyledTitleDisplay>
-
-            <CategoryButtonList value={code.value} subCategory={code.sub} />
-          </ProductListCategoryWrapper>
-        ))}
-      </ul>
-    </ProductListCategoryLayer>
+                <button onClick={handleIsDecaf}>{isDecaf ? <ToggleActive /> : <ToggleDefault />}</button>
+              </StyledDecafTitleDisplay>
+            </CategoryListWrapper>
+          )),
+      )}
+    </CategoryListLayer>
   );
 };
 
 export default CategoryList;
 
-const ProductListCategoryLayer = styled.div`
-  width: 40%;
+const CategoryListLayer = styled.div`
+  max-width: 360px;
   margin-right: 40px;
 `;
 
-const ProductListCategoryWrapper = styled.li`
+const CategoryListWrapper = styled.div`
   border-bottom: 1px solid var(--color-gray-100);
-  padding-bottom: 12px;
+`;
+
+const StyledTitleDisplay = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 30px 0;
 `;
 
 const StyledTitle = styled.h2<{ $fontSize: string; $fontWeight?: string; $margin?: string }>`
@@ -81,18 +91,120 @@ const StyledSubTitle = styled.span`
   margin-left: 8px;
 `;
 
-const StyledTitleDisplay = styled.div`
-  display: flex;
-  align-items: center;
-
-  padding: 12px 0;
-`;
-
-const StyledTitleDisplayContent = styled(StyledTitleDisplay)`
+const StyledDecafTitleDisplay = styled(StyledTitleDisplay)`
   justify-content: space-between;
+  button {
+    border: none;
+    background: none;
+  }
 `;
 
-const StyledToggleButton = styled.button`
-  background: none;
-  border: none;
+const StyledButtonList = styled.div`
+  margin: 30px 0;
 `;
+
+// import styled from "styled-components";
+// import { useState } from "react";
+// import { useRecoilState } from "recoil";
+// import ToggleDefault from "@/assets/icons/ToggleDefault.svg?react";
+// import ToggleActive from "@/assets/icons/ToggleActive.svg?react";
+// import CategoryButtonList from "./CategoryButtonList";
+// import useQueryParams from "@/hooks/useQueryParams";
+// import { nestedCodeState } from "@/recoil/atoms/codeState";
+// import { CATEGORY_TITLE, CATEGORY_CONTENT } from "@/constants/category";
+
+// const CategoryList = () => {
+//   const [codes] = useRecoilState(nestedCodeState);
+
+//   const [isDecaf, setIsDecaf] = useState(false);
+
+//   const handleIsDecaf = () => {
+//     setIsDecaf(!isDecaf);
+//     toggleFilter((!isDecaf).toString());
+//   };
+
+//   const { toggleFilter } = useQueryParams("isDecaf");
+
+//   return (
+//     <CategoryListLayer>
+//       <StyledTitle $fontSize="3.6rem" $fontWeight="var(--weight-bold)" $margin="0 0 60px 0">
+//         전체상품
+//       </StyledTitle>
+
+//       {codes?.productCategory.codes.map(
+//         (item, index) =>
+//           index > 0 &&
+//           (item.sub ? (
+//             <CategoryListWrapper>
+//               <StyledTitleDisplay>
+//                 <StyledTitle $fontSize="1.6rem" $fontWeight="var(--weight-semibold)">
+//                   {CATEGORY_TITLE[item.value]}
+//                 </StyledTitle>
+//                 <StyledSubTitle>{CATEGORY_CONTENT[item.value]}</StyledSubTitle>
+//               </StyledTitleDisplay>
+
+//               <StyledButtonList>
+//                 <CategoryButtonList subCategory={item.sub} value={item.value} />
+//               </StyledButtonList>
+//             </CategoryListWrapper>
+//           ) : (
+//             <CategoryListWrapper>
+//               <StyledDecafTitleDisplay>
+//                 <StyledTitle $fontSize="1.6rem" $fontWeight="var(--weight-semibold)">
+//                   디카페인
+//                 </StyledTitle>
+
+//                 <button onClick={handleIsDecaf}>{isDecaf ? <ToggleActive /> : <ToggleDefault />}</button>
+//               </StyledDecafTitleDisplay>
+//             </CategoryListWrapper>
+//           )),
+//       )}
+//     </CategoryListLayer>
+//   );
+// };
+
+// export default CategoryList;
+
+// const CategoryListLayer = styled.div`
+//   max-width: 360px;
+//   margin-right: 40px;
+// `;
+
+// const CategoryListWrapper = styled.div`
+//   border-bottom: 1px solid var(--color-gray-100);
+// `;
+
+// const StyledTitleDisplay = styled.div`
+//   display: flex;
+//   align-items: center;
+//   margin: 30px 0;
+// `;
+
+// const StyledTitle = styled.h2<{ $fontSize: string; $fontWeight?: string; $margin?: string }>`
+//   font-family: "Maruburi";
+
+//   font-size: ${(props) => props.$fontSize};
+//   font-weight: ${(props) => props.$fontWeight};
+//   margin: ${(props) => props.$margin};
+
+//   color: var(--color-sub-500);
+// `;
+
+// const StyledSubTitle = styled.span`
+//   color: var(--color-gray-300);
+//   font-size: 1rem;
+//   font-weight: var(--weight-thin);
+//   margin-left: 8px;
+// `;
+
+// const StyledDecafTitleDisplay = styled(StyledTitleDisplay)`
+//   justify-content: space-between;
+//   button {
+//     border: none;
+//     background: none;
+//   }
+// `;
+
+// const StyledButtonList = styled.div`
+//   margin: 30px 0;
+// `;

--- a/src/constants/category.ts
+++ b/src/constants/category.ts
@@ -1,0 +1,16 @@
+interface CategoryProps {
+  [key: string]: string;
+}
+const CATEGORY_TITLE: CategoryProps = {
+  isDecaf: "디카페인",
+  teaType: "종류",
+  taste: "맛",
+  hashTag: "상황",
+};
+
+const CATEGORY_CONTENT: CategoryProps = {
+  teaType: "원하는 차 종류를 선택해주세요.",
+  taste: "좋아하는 맛을 선택해주세요.",
+  hashTag: "이럴 땐 이런 맛!",
+};
+export { CATEGORY_TITLE, CATEGORY_CONTENT };


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
- 상품 목록 리스트 카테고리에서 pack 데이터 제외하고 출력하였습니다. 
- 기존 각각 다른 컴포넌트를 사용하던 카테고리 리스트를 디카페인-토글 영역까지 포함할 수 있는 코드로 수정하였습니다. 
- 상품 목록 리스트 카테고리 영문으로 출력되던 타이틀 데이터 한글로 수정했습니다. 타이틀 한글명을 상수화하여 값을 불러왔습니다. 
- 타이틀에 맞는 서브 타이틀 데이터를 추가하였습니다. 서브타이틀을 상수화하여 값을 불러왔습니다. 

## 📸 스크린샷

## 🔗 관련 이슈
#138 #182

## 💬 참고사항
