### PR TITLE
fix(ProductList):카테고리 버튼 리스트 타입 수정(#138)

### DIFF
--- a/src/components/product/productlist/CategoryButtonList.tsx
+++ b/src/components/product/productlist/CategoryButtonList.tsx
@@ -1,19 +1,12 @@
 import styled from "styled-components";
 import CategoryButton from "./CategoryButton";
 import useQueryParams from "@/hooks/useQueryParams";
+import { CodeWithSub } from "@/types/code";
 
 interface CategoryButtonListProps {
   value: string;
-  subCategory: Array<SubCategoryType>;
+  subCategory: CodeWithSub[];
 }
-type SubCategoryType = {
-  sort: number;
-  code: string;
-  value: string;
-  parent: string;
-  depth: number;
-};
-
 const CategoryButtonList = ({ value, subCategory }: CategoryButtonListProps) => {
   const { toggleFilter } = useQueryParams(`${value}`);
 


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
카테고리 버튼 리스트에 받아오는 배열 데이터의 타입을 수정했습니다.
직접 지정한 타입에서 services/code에서 타입 정의한 CodeWithSub을 사용했습니다.

## 📸 스크린샷

## 🔗 관련 이슈
#138 

## 💬 참고사항
