### PR TITLE
fix(logout): 로그아웃 시 cartCheckedItemState 초기화(#211)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { NavLink, useNavigate, useSearchParams, Link, useLocation } from "react-router-dom";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import IconShoppingCart from "@/assets/icons/shoppingCart_40.svg?react";
 import IconSearchCart from "@/assets/icons/search_24.svg?react";
 import { getUserTypeState } from "@/recoil/selectors/loggedInUserSelector";
 import loggedInUserState from "@/recoil/atoms/loggedInUserState";
-import { cartState } from "@/recoil/atoms/cartState";
+import { cartState, cartCheckedItemState } from "@/recoil/atoms/cartState";
 import getProductCategoryValueByCode from "@/recoil/selectors/codeSelector";
 
 // constants
@@ -26,6 +26,7 @@ const Header = () => {
   const userType = useRecoilValue(getUserTypeState);
   const [user, setUser] = useRecoilState(loggedInUserState);
   const [cartStorage, setCartStorage] = useRecoilState(cartState);
+  const setCheckedItem = useSetRecoilState(cartCheckedItemState);
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -55,6 +56,7 @@ const Header = () => {
     setIsLogin(false);
     setUser(null);
     setCartStorage([]);
+    setCheckedItem([]);
   };
 
   const categoryCode = {


### PR DESCRIPTION
## 📤 반영 브랜치
feat/logout-check-cart -> dev

## 🔧 작업 내용
- 로그아웃 시 cartCheckedItemState 초기화 하는 로직을 추가하였습니다.

## 📸 스크린샷

## 🔗 관련 이슈
ex) #111

## 💬 참고사항
