### PR TITLE
feat(cart): 선택상품금액이 0원이면 구매하기 버튼 비활성화 (#134)

### DIFF
--- a/src/containers/cart/CartPriceContainer.tsx
+++ b/src/containers/cart/CartPriceContainer.tsx
@@ -18,6 +18,7 @@ const CartPriceContainer = ({ cartData }: CartPriceContainerProps) => {
   const checkedItems = useRecoilValue(cartCheckedItemState);
   const cartStorage = useRecoilValue(cartState);
   const [checkedPrice, setcheckedPrice] = useState(0);
+  const [shippingFeesDiscount, setShippingFeesDiscount] = useState(0);
 
   const navigate = useNavigate();
 
@@ -44,20 +45,27 @@ const CartPriceContainer = ({ cartData }: CartPriceContainerProps) => {
     setcheckedPrice(sum);
   }, [checkedItems, cartData, cartStorage]);
 
+  useEffect(() => {
+    if (checkedPrice <= 0 || checkedPrice >= FREE_SHIPPING_FEES) setShippingFeesDiscount(SHIPPING_FEES);
+    else setShippingFeesDiscount(0);
+  }, [checkedPrice]);
+
   return (
     <CartPriceContainerLayer>
       <PriceWrapper>
         <Price priceTitle="선택 상품 금액" number={checkedPrice} />
-        <Price priceTitle="배송비" number={checkedPrice > 0 && checkedPrice < FREE_SHIPPING_FEES ? SHIPPING_FEES : 0} />
+        <Price priceTitle="배송비" number={SHIPPING_FEES - shippingFeesDiscount} />
         <div>
-          <Price
-            priceTitle="총 결제 금액"
-            number={checkedPrice > 0 && checkedPrice < FREE_SHIPPING_FEES ? SHIPPING_FEES + checkedPrice : checkedPrice}
-          />
+          <Price priceTitle="총 결제 금액" number={checkedPrice + SHIPPING_FEES - shippingFeesDiscount} />
         </div>
       </PriceWrapper>
       <ButtonWrapper onClick={handleCreateOrder}>
-        <Button value="구매하기" size="lg" variant="point" />
+        <Button
+          value="구매하기"
+          size="lg"
+          variant="point"
+          disabled={!(checkedPrice + SHIPPING_FEES - shippingFeesDiscount)}
+        />
       </ButtonWrapper>
     </CartPriceContainerLayer>
   );


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
- 선택상품금액이 0원인 경우 구매하기 버튼이 비활성화되도록 처리했습니다.

## 📸 스크린샷
<img width="1183" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/17806882-9ac8-4bc5-ab46-f5c6aab1dd79">

## 🔗 관련 이슈
#201 
## 💬 참고사항
