### PR TITLE
feat(cart): 아이템수량이 0이될때 체크박스 상태 변화 구현(#242)

### DIFF
--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -8,13 +8,11 @@ import { CartItem as CartItemType, CartStorageItem } from "@/types/cart";
 import CounterButton from "./CounterButton";
 import loggedInUserState from "@/recoil/atoms/loggedInUserState";
 import cartApi from "@/apis/services/cart";
-import { cartState } from "@/recoil/atoms/cartState";
+import { cartCheckedItemState, cartState } from "@/recoil/atoms/cartState";
 import useQuantityCounter from "@/hooks/useQuantityCounter";
 
 interface CartItemProps {
   setCartData: React.Dispatch<React.SetStateAction<CartItemType[]>>;
-  checkedItems: number[];
-  toggleCheckBox: (product_id: number) => void;
   handleDeleteItem: (_id: number, product_id: number) => void;
   data: CartStorageItem | CartItemType; // 로컬스토리지 데이터 || DB데이터
   idx: number;
@@ -24,10 +22,10 @@ const isLocalData = (object: CartStorageItem | CartItemType) => {
   return typeof (object as CartItemType)._id === undefined;
 };
 
-const CartItem = ({ setCartData, checkedItems, toggleCheckBox, handleDeleteItem, data, idx }: CartItemProps) => {
+const CartItem = ({ setCartData, handleDeleteItem, data, idx }: CartItemProps) => {
   const user = useRecoilValue(loggedInUserState);
   const setCartStorage = useSetRecoilState(cartState);
-  const { handleQuantityInput, quantityInput, setQuantityInputAsStock } = useQuantityCounter(
+  const [checkedItems, setCheckedItems] = useRecoilState(cartCheckedItemState);
     data.quantity,
     user
       ? (data as CartItemType).product.quantity - (data as CartItemType).product.buyQuantity
@@ -43,6 +41,7 @@ const CartItem = ({ setCartData, checkedItems, toggleCheckBox, handleDeleteItem,
     }
   };
 
+      setCheckedItems((prev) => [...prev, product_id]);
   useEffect(() => {
     setCartItemPrice(data.product.price * quantityInput);
   }, [quantityInput, data]);

--- a/src/containers/cart/CartItemContainer.tsx
+++ b/src/containers/cart/CartItemContainer.tsx
@@ -1,7 +1,7 @@
 import { useRecoilState, useRecoilValue } from "recoil";
 import CartItem from "@/components/cart/CartItem";
 import { CartItem as CartItemType } from "@/types/cart";
-import { cartState, cartCheckedItemState } from "@/recoil/atoms/cartState";
+import { cartState } from "@/recoil/atoms/cartState";
 import cartApi from "@/apis/services/cart";
 import loggedInUserState from "@/recoil/atoms/loggedInUserState";
 
@@ -13,13 +13,6 @@ interface CartItemProps {
 const CartItemContainer = ({ cartData, setCartData }: CartItemProps) => {
   const user = useRecoilValue(loggedInUserState);
   const [cartStorage, setCartStorage] = useRecoilState(cartState);
-  const [checkedItems, setCheckedItems] = useRecoilState(cartCheckedItemState);
-
-  // [단일상품 체크박스 토글]
-  const toggleCheckBox = (product_id: number) => {
-    if (checkedItems.includes(product_id)) setCheckedItems(checkedItems.filter((item) => item !== product_id));
-    else setCheckedItems((prev) => [...prev, product_id]);
-  };
 
   const fetchCartItems = async () => {
     try {
@@ -65,8 +58,6 @@ const CartItemContainer = ({ cartData, setCartData }: CartItemProps) => {
               <CartItem
                 key={keyIndex}
                 setCartData={setCartData}
-                checkedItems={checkedItems}
-                toggleCheckBox={toggleCheckBox}
                 handleDeleteItem={handleDeleteItem}
                 data={item}
                 idx={idx}
@@ -79,8 +70,6 @@ const CartItemContainer = ({ cartData, setCartData }: CartItemProps) => {
               <CartItem
                 key={keyIndex}
                 setCartData={setCartData}
-                checkedItems={checkedItems}
-                toggleCheckBox={toggleCheckBox}
                 handleDeleteItem={handleDeleteItem}
                 data={item}
                 idx={idx}

--- a/src/containers/cart/CartItemListContainer.tsx
+++ b/src/containers/cart/CartItemListContainer.tsx
@@ -28,8 +28,8 @@ const CartItemListContainer = ({ cartData, setCartData }: CartItemListContainerP
       const response = await cartApi.checkStockStates(data);
       const { products } = response.data.item;
       products.forEach((item) => {
-        if (item.quantityInStock < item.quantity) {
-          const targetIndex = cartStorage.findIndex((e) => e.product._id === item._id);
+        const targetIndex = cartStorage.findIndex((e) => e.product._id === item._id);
+        if (item.quantityInStock !== cartStorage[targetIndex].stock) {
           const newCartStorageItem = { ...cartStorage[targetIndex], stock: item.quantityInStock };
           const newCartStorage = [...cartStorage];
           newCartStorage.splice(targetIndex, 1, newCartStorageItem);
@@ -57,8 +57,8 @@ const CartItemListContainer = ({ cartData, setCartData }: CartItemListContainerP
       setCheckedItems([]);
       return;
     }
-    if (user) setCheckedItems(cartData.map((item) => item.product_id));
-    else setCheckedItems(cartStorage.map((item) => item.product._id));
+    if (user) setCheckedItems(cartData.filter((item) => item.quantity !== 0).map((item) => item.product_id));
+    else setCheckedItems(cartStorage.filter((item) => item.quantity !== 0).map((item) => item.product._id));
   };
 
   // [선택삭제]
@@ -93,13 +93,23 @@ const CartItemListContainer = ({ cartData, setCartData }: CartItemListContainerP
   // 체크박스 상태가 바뀌면 모든 아이템이 체크되어있는지 확인
   useEffect(() => {
     // 로그인 시
-    if (user) setIsAllChecked(checkedItems.length > 0 && checkedItems.length === cartData.length);
+    if (user)
+      setIsAllChecked(
+        checkedItems.length > 0 &&
+          checkedItems.length ===
+            cartData.filter((item) => item.product.quantity - item.product.buyQuantity !== 0).length,
+      );
     // 비로그인 시
-    else setIsAllChecked(checkedItems.length > 0 && checkedItems.length === cartStorage.length);
+    else
+      setIsAllChecked(
+        checkedItems.length > 0 && checkedItems.length === cartStorage.filter((item) => item.stock !== 0).length,
+      );
   }, [checkedItems]);
 
   useEffect(() => {
-    setCheckedItems(cartData.map((item) => item.product_id));
+    setCheckedItems(
+      cartData.filter((item) => item.product.quantity - item.product.buyQuantity !== 0).map((item) => item.product_id),
+    );
   }, [cartData.length]);
 
   return (

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -18,7 +18,7 @@ const CartPage = () => {
     try {
       const response = await cartApi.getAllItems();
       const { item: items } = response.data;
-      setCheckedItems(items.map((item) => item.product_id));
+      setCheckedItems(items.filter((item) => item.quantity !== 0).map((item) => item.product_id));
       setCartData(items);
     } catch (error) {
       console.error(error);
@@ -28,7 +28,7 @@ const CartPage = () => {
   // 초기 렌더링 - 카트 데이터 GET 요청 + 체크박스 전체 선택으로 리셋
   useEffect(() => {
     if (user) fetchCartItems();
-    else setCheckedItems(cartStorage.map((item) => item.product._id));
+    else setCheckedItems(cartStorage.filter((item) => item.quantity !== 0).map((item) => item.product._id));
   }, []);
 
   return (


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
수량이 0이되면 자동으로 체크박스 해체됩니다.
수량이 0인 상품의 체크박스를 다시 체크하면 자동으로 수량이 1 증가합니다.
재고가 0개인 상품은 체크박스가 비활성화됩니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
