### PR TITLE
feat(상품상세): 재고가 0인 경우 수량인풋 0으로 설정(#252)

### DIFF
--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -103,10 +103,14 @@ const ProductDetailPage = () => {
     setIsStockModalOpen(false);
   };
 
-  const { handleQuantityInput, quantityInput } = useQuantityCounter(
+  const { handleQuantityInput, quantityInput, setQuantityInputAsStock } = useQuantityCounter(
     1,
     itemData ? itemData.quantity - itemData.buyQuantity : 0,
   );
+
+  useEffect(() => {
+    if (itemData && itemData.quantity - itemData.buyQuantity === 0) setQuantityInputAsStock(0);
+  }, [itemData]);
 
   return (
     <ProductDetailPageLayer>


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-detail -> dev

## 🔧 작업 내용
상품재고가 0개인 경우 수량인풋을 0으로 설정하도록 했습니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
