### PR TITLE
feat(cart): DB장바구니개수 변경시 cartStorage에 반영(#255)

### DIFF
--- a/src/containers/cart/CartItemListContainer.tsx
+++ b/src/containers/cart/CartItemListContainer.tsx
@@ -110,6 +110,20 @@ const CartItemListContainer = ({ cartData, setCartData }: CartItemListContainerP
     setCheckedItems(
       cartData.filter((item) => item.product.quantity - item.product.buyQuantity !== 0).map((item) => item.product_id),
     );
+    // 장바구니 DB의 item 개수가 바뀌면 cartStorage에 DB상태 반영
+    const updatedCartStorage = cartData.map((item) => {
+      return {
+        quantity: item.quantity,
+        stock: item.product.quantity - item.product.buyQuantity,
+        product: {
+          _id: item.product._id,
+          name: item.product.name,
+          image: item.product.image,
+          price: item.product.price,
+        },
+      };
+    });
+    setCartStorage(updatedCartStorage);
   }, [cartData.length]);
 
   return (


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
로그인 상태에서도 헤더에서 장바구니 개수를 불러오기 위해
장바구니 DB의 item 개수가 바뀌면 cartStorage에 DB상태 반영하도록 했습니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
헤더에 정확한 수량 반영을 위해 품절된 상품(재고 0개)을 제외한 개수를 반영하도록 작업할 예정입니다.