### PR TITLE
feat(order): 구매요청시 배송준비중을 기본state로 전달(#254)

### DIFF
--- a/src/apis/services/orders.ts
+++ b/src/apis/services/orders.ts
@@ -6,7 +6,8 @@ const ordersApi = {
   checkStocks: (data: RequestCheckStocks) =>
     publicInstance.post<ResponseCreateOrder>("/orders", { ...data, dryRun: true }),
   // POST /orders
-  createOrder: (data: RequestCreateOrder) => privateInstance.post<ResponseCreateOrder>("/orders", data),
+  createOrder: (data: RequestCreateOrder) =>
+    privateInstance.post<ResponseCreateOrder>("/orders", { ...data, state: "OS030" }),
   // GET /orders
   getOrderList: () => privateInstance.get<ResponseGetOrderList>("/orders"),
 };


### PR DESCRIPTION
## 📤 반영 브랜치
feat/order-checkout -> dev

## 🔧 작업 내용
- 구매하기API 요청함수에서 배송상태를 OS030(배송준비중)으로 설정되도록 수정했습니다.
## 📸 스크린샷
<img width="990" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/bce84041-8d13-46f9-91e5-d5436b2d7cec">

## 🔗 관련 이슈

## 💬 참고사항
