### PR TITLE
fix(ProductList): 상품 정렬 버튼 컴포넌트에 보내는 데이터 수정(#266)

### DIFF
--- a/src/components/product/productlist/ProductSortButtons.tsx
+++ b/src/components/product/productlist/ProductSortButtons.tsx
@@ -1,21 +1,25 @@
 import styled from "styled-components";
-import { Product } from "@/types/products";
 
-interface ProductItemListProps {
-  products: Product[];
+interface ProductSortButtonsProps {
+  productLength: number;
 }
+const ProductSortButtons = ({ productLength }: ProductSortButtonsProps) => {
+  const changeQueryString = () => {
+    // 쿼리스트링 변경하는 코드
+  };
 
-const ProductSortButtons = ({ products }: ProductItemListProps) => {
   return (
     <CategorySortWrapper>
       <li>
-        <StyledProductCount>전체 {products.length}개</StyledProductCount>
+        <StyledProductCount>전체 {productLength}개</StyledProductCount>
       </li>
       <li>
-        <StyledCategorySortButton>인기순</StyledCategorySortButton>
-        <StyledCategorySortButton>최신순</StyledCategorySortButton>
-        <StyledCategorySortButton>높은가격순</StyledCategorySortButton>
-        <StyledCategorySortButton>낮은가격순</StyledCategorySortButton>
+        <StyledCategorySortButton onClick={changeQueryString} type="button">
+          인기순
+        </StyledCategorySortButton>
+        <StyledCategorySortButton type="button">최신순</StyledCategorySortButton>
+        <StyledCategorySortButton type="button">낮은가격순</StyledCategorySortButton>
+        <StyledCategorySortButton type="button">높은가격순</StyledCategorySortButton>
       </li>
     </CategorySortWrapper>
   );

--- a/src/containers/product/ProductSortContainer.tsx
+++ b/src/containers/product/ProductSortContainer.tsx
@@ -57,7 +57,7 @@ const ProductSortContainer = () => {
 
   return (
     <div>
-      <ProductSortButtons products={products} />
+      <ProductSortButtons productLength={products.length} />
       <ProductItemList products={products} />
     </div>
   );


### PR DESCRIPTION
## 📤 반영 브랜치
ex) feat/login -> dev

## 🔧 작업 내용
상품 정렬 버튼이 모여있는 컴포넌트에 보내는 데이터를 수정했습니다.
기존에는 products 정보 전체를 보내는 방식이었으나, 
정렬 버튼 클릭 시 쿼리스트링을 변경하고 쿼리스트링이 변경되면 데이터 요청 보내는 코드를 상위 컴포넌트인 ProductSortContainer에 추가함에 따라 products의 length 속성만 props로 넘겨주는 방식으로 변경했습니다.

## 📸 스크린샷

## 🔗 관련 이슈
#266 

## 💬 참고사항
