### PR TITLE
fix(ProductList): 카테고리버튼 disabled 속성 추가(#216)

### DIFF
--- a/src/components/product/productlist/CategoryButton.tsx
+++ b/src/components/product/productlist/CategoryButton.tsx
@@ -4,6 +4,7 @@ interface ButtonProps {
   variant: "active" | "default";
   children: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
 }
 
 const VARIANTS = {
@@ -19,11 +20,11 @@ const VARIANTS = {
   `,
 };
 
-const CategoryButton = ({ variant, children, onClick }: ButtonProps) => {
+const CategoryButton = ({ variant, children, onClick, disabled }: ButtonProps) => {
   const variantStyle = VARIANTS[variant];
 
   return (
-    <StyledButton $variantStyle={variantStyle} onClick={onClick}>
+    <StyledButton $variantStyle={variantStyle} onClick={onClick} disabled={disabled}>
       {children}
     </StyledButton>
   );
@@ -37,6 +38,10 @@ const StyledButton = styled.button<{ $variantStyle: RuleSet<object> }>`
   border: 0;
   padding: 6px 10px;
   cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+  }
 `;
 
 export default CategoryButton;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
카테고리 버튼에 disabled 속성을 옵셔널로 추가했습니다. 
disabled 속성을 추가한 카테고리 버튼은 클릭이 안 되고 focus가 잡히지 않습니다. 

사용 예시
```jsx
<CategoryButton
  key={index}
  variant="default"
  onClick={() => toggleFilter(`${category.code}`)}
 disabled
>
  버튼
</CategoryButton>
```

## 📸 스크린샷
<img width="69" alt="카테고리버튼" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/17eed2b1-d17b-4258-ba2b-0d8fbdb5552f">

## 🔗 관련 이슈
#216 

## 💬 참고사항
