### PR TITLE
feat(구매하기): 접속시 아이템이 없는경우 홈으로 이동(#126)

### DIFF
--- a/src/containers/orderCheckout/OrderInfoContainer.tsx
+++ b/src/containers/orderCheckout/OrderInfoContainer.tsx
@@ -5,17 +5,17 @@ import ShippingInfoContainer from "./ShippingInfoContainer";
 import { CartItem } from "@/types/cart";
 import { ShippingInfoType } from "@/types/orders";
 
-interface OrderInfoProps {
+interface OrderInfoContainerProps {
   cartData: CartItem[] | undefined;
   setShippingInfo: React.Dispatch<React.SetStateAction<ShippingInfoType | undefined>>;
 }
 
-const OrderInfo = ({ cartData, setShippingInfo }: OrderInfoProps) => {
+const OrderInfoContainer = ({ cartData, setShippingInfo }: OrderInfoContainerProps) => {
   return (
     <>
       <Section>
         <SectionTitle>주문 상품</SectionTitle>
-        {cartData ? <OrderListContainer cartData={cartData} /> : <p>상품이 없습니다.</p>}
+        {cartData ? <OrderListContainer cartData={cartData} /> : null}
       </Section>
       <Section>
         <SectionTitle>주문자 정보</SectionTitle>
@@ -29,7 +29,7 @@ const OrderInfo = ({ cartData, setShippingInfo }: OrderInfoProps) => {
   );
 };
 
-export default OrderInfo;
+export default OrderInfoContainer;
 
 const Section = styled.section`
   margin: 40px 0;

--- a/src/containers/orderCheckout/OrderInfoContainer.tsx
+++ b/src/containers/orderCheckout/OrderInfoContainer.tsx
@@ -1,4 +1,6 @@
 import { styled } from "styled-components";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import OrderListContainer from "./OrderListContainer";
 import UserInfoContainer from "@/containers/orderCheckout/UserInfoContainer";
 import ShippingInfoContainer from "./ShippingInfoContainer";
@@ -11,6 +13,11 @@ interface OrderInfoContainerProps {
 }
 
 const OrderInfoContainer = ({ cartData, setShippingInfo }: OrderInfoContainerProps) => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!cartData || cartData.length <= 0) navigate("/", { replace: true });
+  }, []);
   return (
     <>
       <Section>

--- a/src/pages/OrderCheckoutPage.tsx
+++ b/src/pages/OrderCheckoutPage.tsx
@@ -2,7 +2,7 @@ import { styled } from "styled-components";
 import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { useNavigate } from "react-router-dom";
-import OrderInfo from "@/containers/orderCheckout/OrderInfo";
+import OrderInfoContainer from "@/containers/orderCheckout/OrderInfoContainer";
 import OrderPriceContainer from "@/containers/orderCheckout/OrderPriceContainer";
 import { CartItem } from "@/types/cart";
 import cartApi from "@/apis/services/cart";
@@ -84,7 +84,7 @@ const OrderCheckoutPage = () => {
         </ButtonWrapper>
       </Modal>
       <PageLeft>
-        <OrderInfo cartData={cartData} setShippingInfo={setShippingInfo} />
+        <OrderInfoContainer cartData={cartData} setShippingInfo={setShippingInfo} />
       </PageLeft>
       <PageRight>
         <OrderPriceContainer cartData={cartData} />


### PR DESCRIPTION
## 📤 반영 브랜치
feat/order-checkout -> dev

## 🔧 작업 내용
구매하기페이지 접근 시 아이템이 없는 경우 홈으로 이동하도록 구현했습니다.
replace: true로 설정하여 뒤로가기하더라도 구매하기페이지로 다시 돌아오지 않도록 했습니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
