### PR TITLE
feat(상품상세): 바로구매기능 구현(#204)

### DIFF
--- a/src/containers/orderCheckout/OrderInfoContainer.tsx
+++ b/src/containers/orderCheckout/OrderInfoContainer.tsx
@@ -1,6 +1,6 @@
 import { styled } from "styled-components";
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import OrderListContainer from "./OrderListContainer";
 import UserInfoContainer from "@/containers/orderCheckout/UserInfoContainer";
 import ShippingInfoContainer from "./ShippingInfoContainer";
@@ -14,15 +14,17 @@ interface OrderInfoContainerProps {
 
 const OrderInfoContainer = ({ cartData, setShippingInfo }: OrderInfoContainerProps) => {
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
+    if (location.state) return;
     if (!cartData || cartData.length <= 0) navigate("/", { replace: true });
   }, []);
   return (
     <>
       <Section>
         <SectionTitle>주문 상품</SectionTitle>
-        {cartData ? <OrderListContainer cartData={cartData} /> : null}
+        <OrderListContainer cartData={cartData!} orderData={location.state} />
       </Section>
       <Section>
         <SectionTitle>주문자 정보</SectionTitle>

--- a/src/containers/orderCheckout/OrderListContainer.tsx
+++ b/src/containers/orderCheckout/OrderListContainer.tsx
@@ -1,11 +1,23 @@
 import OrderItem from "@/components/orderCheckout/OrderItem";
 import { CartItem } from "@/types/cart";
+import { OrderFromDetailPage } from "@/types/orders";
 
 interface OrderListContainerProps {
   cartData: CartItem[];
+  orderData: OrderFromDetailPage;
 }
 
-const OrderListContainer = ({ cartData }: OrderListContainerProps) => {
+const OrderListContainer = ({ cartData, orderData }: OrderListContainerProps) => {
+  if (orderData) {
+    return (
+      <OrderItem
+        imgUrl={orderData.mainImages[0]}
+        name={orderData.name}
+        quantity={orderData.quantityInput}
+        priceSum={orderData.price * orderData.quantityInput}
+      />
+    );
+  }
   return (
     <>
       {cartData.map((item, idx) => {

--- a/src/containers/orderCheckout/OrderPriceContainer.tsx
+++ b/src/containers/orderCheckout/OrderPriceContainer.tsx
@@ -1,5 +1,6 @@
 import { styled } from "styled-components";
 import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import Price from "@/components/common/Price";
 import { CartItem } from "@/types/cart";
 import { SHIPPING_FEES, FREE_SHIPPING_FEES } from "@/constants/order";
@@ -10,8 +11,13 @@ interface OrderPriceContainerProps {
 
 const OrderPriceContainer = ({ cartData }: OrderPriceContainerProps) => {
   const [priceSum, setPriceSum] = useState(0);
+  const location = useLocation();
 
   useEffect(() => {
+    if (location.state) {
+      setPriceSum(location.state.price * location.state.quantityInput);
+      return;
+    }
     if (cartData) {
       setPriceSum(cartData.map((item) => item.quantity * item.product.price).reduce((a, b) => a + b, 0));
     }

--- a/src/pages/OrderCheckoutPage.tsx
+++ b/src/pages/OrderCheckoutPage.tsx
@@ -69,6 +69,7 @@ const OrderCheckoutPage = () => {
 
   useEffect(() => {
     if (user) fetchAllCartItems();
+    else navigate("/", { replace: true });
   }, []);
 
   return (

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -92,11 +92,8 @@ const ProductDetailPage = () => {
   };
 
   const handleCheckoutOrder = () => {
-    if (!user) {
-      setIsLoginModalOpen(true);
-      return;
-    }
-    setIsCheckoutConfirmModalOpen(true);
+    setIsCheckoutConfirmModalOpen(false);
+    navigate("/orders/checkout", { state: { ...itemData, quantityInput } });
   };
 
   const handleStockUpdate = () => {
@@ -143,7 +140,7 @@ const ProductDetailPage = () => {
         <ButtonWrapper onClick={() => setIsCheckoutConfirmModalOpen(false)}>
           <Button value="취소" size="sm" variant="sub" />
         </ButtonWrapper>
-        <ButtonWrapper onClick={() => navigate("/orders/checkout")}>
+        <ButtonWrapper onClick={handleCheckoutOrder}>
           <Button value="구매하기" size="sm" variant="point" />
         </ButtonWrapper>
       </Modal>
@@ -189,7 +186,7 @@ const ProductDetailPage = () => {
           <MainButtonWrapper onClick={handleAddToCart}>
             <Button value="장바구니" size="lg" variant="sub" disabled={!quantityInput} />
           </MainButtonWrapper>
-          <MainButtonWrapper onClick={handleCheckoutOrder}>
+          <MainButtonWrapper onClick={() => (user ? setIsCheckoutConfirmModalOpen(true) : setIsLoginModalOpen(true))}>
             <Button value="바로구매" size="lg" variant="point" disabled={!quantityInput} />
           </MainButtonWrapper>
         </ButtonArea>

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -1,3 +1,5 @@
+import { ProductDetailWithReplies } from "./products";
+
 interface OrderProduct {
   _id: number;
   quantity: number;
@@ -41,6 +43,10 @@ export interface ShippingInfoType {
   name: string;
   phone: string;
   address: OrderAddress;
+}
+
+export interface OrderFromDetailPage extends ProductDetailWithReplies {
+  quantityInput: number;
 }
 
 // Request Types


### PR DESCRIPTION
## 📤 반영 브랜치
feat/order-checkout -> dev

## 🔧 작업 내용
- 바로구매 클릭시 navigate함수의 state에 아이템정보와 구매수량을 전달합니다.
- 구매하기페이지에서 useLocation을 사용해 state값을 불러옵니다.
- state값이 존재하는 경우 해당 구매정보만 보여주고, 그렇지않으면 카트정보를 불러옵니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
