### PR TITLE
feat(ProductList): 필터 버튼 클릭 시 버튼 색상 변경(#210)

### DIFF
--- a/src/components/product/productlist/CategoryButton.tsx
+++ b/src/components/product/productlist/CategoryButton.tsx
@@ -1,10 +1,11 @@
+import { useLocation } from "react-router-dom";
 import styled, { RuleSet, css } from "styled-components";
 
 interface ButtonProps {
-  variant: "active" | "default";
   children: string;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
+  code: string;
+  toggleFilter: (id: string) => void;
 }
 
 const VARIANTS = {
@@ -20,11 +21,16 @@ const VARIANTS = {
   `,
 };
 
-const CategoryButton = ({ variant, children, onClick, disabled }: ButtonProps) => {
-  const variantStyle = VARIANTS[variant];
+const CategoryButton = ({ children, toggleFilter, code, disabled }: ButtonProps) => {
+  const location = useLocation();
+  const queryString = location.search;
 
   return (
-    <StyledButton $variantStyle={variantStyle} onClick={onClick} disabled={disabled}>
+    <StyledButton
+      $variantStyle={queryString.includes(code) ? VARIANTS.active : VARIANTS.default}
+      onClick={() => toggleFilter(code)}
+      disabled={disabled}
+    >
       {children}
     </StyledButton>
   );

--- a/src/components/product/productlist/CategoryButtonList.tsx
+++ b/src/components/product/productlist/CategoryButtonList.tsx
@@ -13,7 +13,7 @@ const CategoryButtonList = ({ value, subCategory }: CategoryButtonListProps) => 
   return (
     <CategoryButtonListLayer>
       {subCategory.map((category) => (
-        <CategoryButton key={category.sort} variant="default" onClick={() => toggleFilter(`${category.code}`)}>
+        <CategoryButton key={category.sort + category.code} toggleFilter={toggleFilter} code={category.code}>
           {category.value}
         </CategoryButton>
       ))}


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
카테고리 버튼 클릭 시 활성화된 버튼의 색상을 변경하는 코드를 추가했습니다.
useLocation 객체의 search 메서드를 통해 쿼리스트링을 저장하고, 저장한 쿼리스트링에 클릭한 버튼의 code가 포함되어 있으면 active 스타일을 적용하였습니다. 

## 📸 스크린샷
https://github.com/Eurachacha/hanmogeum/assets/117130358/b4f1becb-92f2-48ac-a0db-41c835b67fc2

## 🔗 관련 이슈
#87  #210 

## 💬 참고사항
