### PR TITLE
feat(ProductList): 상품 클릭 시 상품 세부로 이동(#280)

### DIFF
--- a/src/components/product/productlist/ProductItem.tsx
+++ b/src/components/product/productlist/ProductItem.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 import ProductItemLabel from "./ProductItemLabel";
 import { Product } from "@/types/products";
 
@@ -7,8 +8,10 @@ interface ProductItemProps {
 }
 
 const ProductItem = ({ product }: ProductItemProps) => {
+  const navigate = useNavigate();
+
   return (
-    <ProductItemLayer>
+    <ProductItemLayer onClick={() => navigate(`/products/${product._id}`)}>
       <ProductItemImageWrapper $imageUrl={product.mainImages}>
         <StyledLabel>
           <li>
@@ -60,6 +63,7 @@ const ProductItemLayer = styled.div`
   border-radius: 5px;
   overflow: hidden;
   box-shadow: 0 6px 6px -3px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
 `;
 
 const ProductItemImageWrapper = styled.div<{ $imageUrl: string[] }>`


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
상품을 클릭하면 product 객체 내 id 값을 바탕으로 상품 세부 페이지로 이동하는 코드를 추가했습니다.

## 📸 스크린샷
https://github.com/Eurachacha/hanmogeum/assets/117130358/de294949-666c-486d-bdad-ed1ae207e28e


## 🔗 관련 이슈
#280 

## 💬 참고사항
