### PR TITLE
fix(orderList): 주문 목록 페이지 기능 추가(#192)

### DIFF
--- a/src/apis/services/mypage.ts
+++ b/src/apis/services/mypage.ts
@@ -1,10 +1,14 @@
 import { privateInstance } from "../instance";
-import { ResponseDataMyOrderList } from "@/types/myPage";
+import { ResponseDataMyOrderList, getMyPageOrderListProps } from "@/types/myPage";
 
 const myPageApi = {
-  getMyPageOrderList: () => privateInstance.get<ResponseDataMyOrderList>(`/orders`),
-  getMyPageOrderByShippingCode: (state: string) =>
-    privateInstance.get<ResponseDataMyOrderList>(`/orders?custom={"state":"${state}"}`),
+  getMyPageOrderList: ({ state, createdAt }: getMyPageOrderListProps) => {
+    const baseURL = "/orders?";
+    const shippingCodeFilter = state ? `"state":"${state}"` : ``;
+    const periodFilter = createdAt ? `"createdAt":{"$gte":"${createdAt.startDate}","$lt":"${createdAt.endDate}"}` : "";
+    const resultURL =
+      baseURL + (shippingCodeFilter || periodFilter ? `custom={${[shippingCodeFilter, periodFilter].join("")}}` : "");
+    return privateInstance.get<ResponseDataMyOrderList>(resultURL);
+  },
 };
-
 export default myPageApi;

--- a/src/assets/icons/dropDownArrow.svg
+++ b/src/assets/icons/dropDownArrow.svg
@@ -1,0 +1,8 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_949_557" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="25" height="25">
+<rect x="0.498047" y="0.289062" width="24" height="24" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_949_557)">
+<path d="M12.498 15.2891L7.49805 10.2891H17.498L12.498 15.2891Z" fill="#7E7E7E"/>
+</g>
+</svg>

--- a/src/components/MypageDashBoard/WidgetShipping.tsx
+++ b/src/components/MypageDashBoard/WidgetShipping.tsx
@@ -15,9 +15,9 @@ const WidgetShipping = () => {
   ]);
   const getShippingData = async () => {
     try {
-      const response1 = await myPageApi.getMyPageOrderByShippingCode(shippingInfo[0].code);
-      const response2 = await myPageApi.getMyPageOrderByShippingCode(shippingInfo[1].code);
-      const response3 = await myPageApi.getMyPageOrderByShippingCode(shippingInfo[2].code);
+      const response1 = await myPageApi.getMyPageOrderList({ state: shippingInfo[0].code });
+      const response2 = await myPageApi.getMyPageOrderList({ state: shippingInfo[1].code });
+      const response3 = await myPageApi.getMyPageOrderList({ state: shippingInfo[2].code });
       const updatedState = { ...shippingInfo };
       updatedState[0].value = response1.data.item.length;
       updatedState[1].value = response2.data.item.length;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,147 @@
+import styled, { RuleSet, css } from "styled-components";
+import React, { useState, useCallback } from "react";
+import DropDownArrow from "@/assets/icons/dropDownArrow.svg?react";
+
+interface DropdownProps {
+  name: string;
+  variant?: "normal";
+  list: string[];
+  style?: React.CSSProperties;
+  defaultIndex?: number;
+  onItemSelected?: (index: number, item: string) => void;
+  onOpen?: () => void;
+  onClose?: () => void;
+}
+
+interface CustomProperties {
+  $variantStyle?: RuleSet<object>;
+}
+
+interface SelectItemStyleProps {
+  $isSelected: boolean;
+}
+interface SelectItemWrapperProps {
+  $isOpen: boolean;
+}
+interface SelectedItemWrapperProps {
+  $isOpen: boolean;
+}
+
+const VARIANTS = {
+  normal: css`
+    border: 1px solid var(--color-gray-200, #ddd);
+  `,
+};
+
+// TODO : 공용 컴포넌트에 맞게 다시 리팩토링
+const Dropdown = ({
+  name,
+  variant = "normal",
+  list,
+  style,
+  defaultIndex = 0,
+  onItemSelected,
+  onOpen,
+  onClose,
+}: DropdownProps) => {
+  const [currentIndex, setCurrentIndex] = useState(defaultIndex);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const variantStyle = VARIANTS[variant] || VARIANTS.normal;
+
+  const handleDropdownClick = useCallback(() => {
+    setIsOpen(!isOpen);
+    if (isOpen) {
+      if (onOpen) {
+        onOpen();
+      }
+    } else if (onClose) {
+      onClose();
+    }
+  }, [isOpen, onOpen, onClose]);
+
+  const handleItemClick = useCallback(
+    (index: number) => {
+      setCurrentIndex(index);
+      setIsOpen(false);
+      if (onItemSelected) {
+        onItemSelected(index, list[index]);
+      }
+    },
+    [list, onItemSelected],
+  );
+
+  return (
+    <DropdownLayer onClick={handleDropdownClick} $variantStyle={variantStyle} style={style} aria-expanded={isOpen}>
+      <SelectedItemWrapper $isOpen={isOpen}>
+        <span>{list[currentIndex]}</span>
+        <DropDownArrow />
+      </SelectedItemWrapper>
+      {isOpen && (
+        <SelectItemWrapper $isOpen={isOpen} style={{ display: isOpen ? "flex" : "none" }}>
+          {list.map((item, idx) => {
+            const key = `${name}-${idx}`;
+            return (
+              <SelectItemStyle key={key} onClick={() => handleItemClick(idx)} $isSelected={idx === currentIndex}>
+                {item}
+              </SelectItemStyle>
+            );
+          })}
+        </SelectItemWrapper>
+      )}
+    </DropdownLayer>
+  );
+};
+
+export default Dropdown;
+
+const DropdownLayer = styled.div<CustomProperties>`
+  width: 100%;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0.5rem 1.4rem;
+  border-radius: 1px;
+  cursor: pointer;
+  ${(props) => props.$variantStyle}
+`;
+
+const SelectedItemWrapper = styled.div<SelectedItemWrapperProps>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  svg {
+    transition: all ease-in-out 0.14s;
+    transform: ${(props) => (props.$isOpen ? `rotate(180deg)` : `none`)};
+  }
+`;
+
+const SelectItemWrapper = styled.div<SelectItemWrapperProps>`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 105%;
+  left: 0;
+  right: 0;
+  background-color: white;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1;
+  overflow: hidden;
+`;
+
+const SelectItemStyle = styled.div<SelectItemStyleProps>`
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1.4rem;
+  height: 4rem;
+  color: ${(props) => (props.$isSelected ? `var(--color-sub-500)` : `inherit`)};
+  font-weight: ${(props) => (props.$isSelected ? `var(--weight-bold)` : `inherit`)};
+  &:hover {
+    background-color: var(--color-sub-500);
+    color: var(--color-white);
+  }
+`;

--- a/src/components/mypage/ContainerHeader..tsx
+++ b/src/components/mypage/ContainerHeader..tsx
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from "react";
 import styled, { RuleSet, css } from "styled-components";
 
 interface ContainerHeaderProps {
@@ -18,19 +19,28 @@ const VARIANTS = {
   `,
 };
 
-const ContainerHeader = ({ title, variant = "main" }: ContainerHeaderProps) => {
+const ContainerHeader = ({ title, variant = "main", children }: PropsWithChildren<ContainerHeaderProps>) => {
   const variantStyle = VARIANTS[variant];
-  return <ContainerHeaderLayer $variantStyle={variantStyle}>{title}</ContainerHeaderLayer>;
+  return (
+    <ContainerHeaderLayer $variantStyle={variantStyle}>
+      <TitleWrapper>{title}</TitleWrapper>
+      {children}
+    </ContainerHeaderLayer>
+  );
 };
+
+export default ContainerHeader;
 
 const ContainerHeaderLayer = styled.div<CustomProperties>`
   ${(props) => props.$variantStyle}
+  display: flex;
   width: 100%;
   height: 5rem;
-  font-weight: var(--weight-bold);
-  font-size: 2.4rem;
   border-bottom: 1px solid var(--color-black);
   border-bottom: 1px solid var(--color-gray-200);
 `;
 
-export default ContainerHeader;
+const TitleWrapper = styled.div`
+  font-weight: var(--weight-bold);
+  font-size: 2.4rem;
+`;

--- a/src/containers/mypage/MyOrderDetailContainer.tsx
+++ b/src/containers/mypage/MyOrderDetailContainer.tsx
@@ -2,16 +2,12 @@ import { useState, useEffect } from "react";
 import styled from "styled-components";
 import { useParams, useNavigate } from "react-router-dom";
 
-import { useRecoilState } from "recoil";
 import { MyOrderItem, Product } from "@/types/myPage";
 import myPageApi from "@/apis/services/mypage";
-import OrderItem from "@/components/mypage/OrderItem";
-import OrderItemContentsText from "@/components/mypage/OrderItemContentsText";
 import Button from "@/components/common/Button";
 import OrderDetailInfo from "@/components/mypage/OrderDetailInfo";
 import getPriceFormat from "@/utils/getPriceFormat";
 import ContainerHeader from "@/components/mypage/ContainerHeader.";
-// import OrderDetailItem from "@/components/mypage/OrderDetailItem";
 import cartApi from "@/apis/services/cart";
 
 const MyOrderDetailContainer = () => {
@@ -21,7 +17,7 @@ const MyOrderDetailContainer = () => {
 
   const requestGetMyOrderList = async () => {
     try {
-      const { data } = await myPageApi.getMyPageOrderList();
+      const { data } = await myPageApi.getMyPageOrderList({});
       if (data.ok === 1) {
         const orderItemList = data.item;
         const orderItem = orderItemList.find((item) => `${item._id}` === `${id}`);
@@ -52,7 +48,7 @@ const MyOrderDetailContainer = () => {
   return (
     <MyOrderDetailContainerLayer>
       <div>
-        <ContainerHeader title={`주문 번호 : ${orderDetail?._id}`} />
+        <ContainerHeader title={`주문 번호 : ${id}`} />
         {orderDetail?.products.map((product, idx) => {
           const orderItemKey = `MypageLayoutContainer_${product._id}${idx}`;
           return (

--- a/src/containers/mypage/MyOrderListContainer.tsx
+++ b/src/containers/mypage/MyOrderListContainer.tsx
@@ -14,17 +14,42 @@ import { flattenCodeState } from "@/recoil/atoms/codeState";
 import { FlattenData } from "@/types/code";
 import getPriceFormat from "@/utils/getPriceFormat";
 import ContainerHeader from "@/components/mypage/ContainerHeader.";
+import Dropdown from "@/components/common/Dropdown";
+import GetDateNow from "../../utils/getDateNow";
 
 const MyOrderListContainer = () => {
   const maxTitleLength = 15;
   const [orderList, setOrderList] = useState<MyOrderItem[]>([]);
+  const [dropDownIdx, setDropDownIdx] = useState(0);
+
+  const dropDownList = ["3개월", "6개월", "1년", "3년"];
+  const dropDownData = [
+    { name: "3개월", type: "month", typeValue: -3 },
+    { name: "6개월", type: "month", typeValue: -6 },
+    { name: "1년", type: "year", typeValue: -1 },
+    { name: "3년", type: "year", typeValue: -3 },
+  ];
   const navigator = useNavigate();
 
   const flattenCodeDataState: FlattenData = useRecoilValue(flattenCodeState);
 
+  const getFilterStartAndEndDate = () => {
+    const getDateNow = new GetDateNow();
+    const endDate = getDateNow.getDateYearMonthDay() || "";
+    let startDate = "";
+    if (dropDownData[dropDownIdx].type === "month") {
+      startDate = getDateNow.getDateMonth(dropDownData[dropDownIdx].typeValue);
+    } else if (dropDownData[dropDownIdx].type === "year") {
+      startDate = getDateNow.getDateYear(dropDownData[dropDownIdx].typeValue);
+    }
+
+    return { startDate, endDate };
+  };
+
   const requestGetMyOrderList = async () => {
+    const { startDate, endDate } = getFilterStartAndEndDate();
     try {
-      const { data } = await myPageApi.getMyPageOrderList();
+      const { data } = await myPageApi.getMyPageOrderList({ createdAt: { startDate, endDate } });
       if (data.ok === 1) {
         const orderItemList = data.item;
         setOrderList(() => [...orderItemList]);
@@ -66,42 +91,65 @@ const MyOrderListContainer = () => {
 
   useEffect(() => {
     requestGetMyOrderList();
-  }, []);
+  }, [dropDownIdx]);
 
   return (
     <MyOrderListContainerLayer>
-      <ContainerHeader title="주문 내역" />
       <OrderItemListWrapper>
-        {orderList.map((order, idx) => {
-          const mapKey = `${idx}_${order._id}_${order.createdAt}`;
-          const orderThumbnail = orderItemToThumbnailData(order);
-          return (
-            <OrderWrapper key={mapKey} onClick={() => detailButtonClickHandle(`${order._id}`)}>
-              <OrderInfoWrapper>
-                <span>{orderThumbnail.id}</span>
-                <span>{orderThumbnail.date}</span>
-              </OrderInfoWrapper>
-              <OrderItem productImageURL={orderThumbnail.imgURL}>
-                <OrderItemContentsText
-                  textList={[`${orderThumbnail.title}`, `${orderThumbnail.totalPrice}`]}
-                  subTextList={[`${orderThumbnail.date} 주문`]}
-                />
-                <ItemRightContentsStyle>
-                  <span>{`${orderThumbnail.shippingState}`}</span>
-                  <DetailButtonWrapper>
-                    <Button value="주문 상세보기" size="md" variant="point" />
-                  </DetailButtonWrapper>
-                </ItemRightContentsStyle>
-              </OrderItem>
-            </OrderWrapper>
-          );
-        })}
+        <ContainerHeader title="주문 내역">
+          <PeriodContentsWrapper>
+            <DropDownWrapper>
+              <Dropdown
+                onItemSelected={(index) => {
+                  setDropDownIdx(index);
+                }}
+                name="period"
+                list={dropDownList}
+              />
+            </DropDownWrapper>
+          </PeriodContentsWrapper>
+        </ContainerHeader>
+
+        <OrderListWrapper>
+          {orderList.map((order, idx) => {
+            const mapKey = `${idx}_${order._id}_${order.createdAt}`;
+            const orderThumbnail = orderItemToThumbnailData(order);
+            return (
+              <OrderWrapper key={mapKey} onClick={() => detailButtonClickHandle(`${order._id}`)}>
+                <OrderInfoWrapper>
+                  <span>주문 번호 {orderThumbnail.id}</span>
+                  <span>{orderThumbnail.date}</span>
+                </OrderInfoWrapper>
+                <OrderItem productImageURL={orderThumbnail.imgURL}>
+                  <OrderItemContentsText
+                    textList={[`${orderThumbnail.title}`, `${orderThumbnail.totalPrice}`]}
+                    subTextList={[`${orderThumbnail.date} 주문`]}
+                  />
+                  <ItemRightContentsStyle>
+                    <span>{`${orderThumbnail.shippingState}`}</span>
+                    <DetailButtonWrapper>
+                      <Button value="주문 상세보기" size="md" variant="point" />
+                    </DetailButtonWrapper>
+                  </ItemRightContentsStyle>
+                </OrderItem>
+              </OrderWrapper>
+            );
+          })}
+        </OrderListWrapper>
       </OrderItemListWrapper>
     </MyOrderListContainerLayer>
   );
 };
 export default MyOrderListContainer;
+const PeriodContentsWrapper = styled.div`
+  margin-left: auto;
+`;
 
+const OrderListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+`;
 const OrderWrapper = styled.div`
   cursor: pointer;
 `;
@@ -109,7 +157,7 @@ const OrderWrapper = styled.div`
 const OrderItemListWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 4rem;
+  gap: 1.6rem;
 `;
 
 const MyOrderListContainerLayer = styled.div`
@@ -123,7 +171,7 @@ const OrderInfoWrapper = styled.div`
   gap: 1rem;
   font-size: 1.6rem;
   font-weight: var(--weight-bold);
-  margin-bottom: 1.6rem;
+  margin-bottom: 1.2rem;
   :first-child {
     padding-right: 1rem;
     border-right: 2px solid var(--color-gray-500);
@@ -146,4 +194,13 @@ const ItemRightContentsStyle = styled.div`
 const DetailButtonWrapper = styled.div`
   height: 5rem;
   width: 16rem;
+`;
+
+const DropDownWrapper = styled.div`
+  width: 14rem;
+  height: 4rem;
+  font-size: 1.4rem;
+  & > div {
+    height: 4rem;
+  }
 `;

--- a/src/types/myPage.ts
+++ b/src/types/myPage.ts
@@ -88,3 +88,13 @@ export interface SignUpDataType {
   address: string;
   addressDetail: string;
 }
+
+// API Props
+
+export interface getMyPageOrderListProps {
+  state?: string;
+  createdAt?: {
+    startDate: string;
+    endDate: string;
+  };
+}

--- a/src/utils/getDateNow.ts
+++ b/src/utils/getDateNow.ts
@@ -1,0 +1,58 @@
+/** 사용법
+const getDateInstance = new GetDate('2023.11.14 13:04:08');
+console.log (getDateInstance.getDateYearMonthDay()) // 2023.11.14
+*/
+
+// 입력받은 날짜를 기준으로 원하는 값을 리턴하는 클래스
+class GetDateNow {
+  dateTime: Date;
+
+  date = { year: "", month: "", day: "", hours: "", minutes: "", seconds: "" };
+
+  constructor() {
+    this.dateTime = new Date();
+    this.#setDate();
+  }
+
+  #setDate() {
+    if (this.dateTime !== null) {
+      this.date.year = `${this.dateTime.getFullYear()}`;
+      this.date.month = `${this.dateTime.getMonth() + 1}`;
+      this.date.day = `${this.dateTime.getDate()}`;
+      this.date.hours = `${this.dateTime.getHours()}`;
+      this.date.minutes = `${this.dateTime.getMinutes()}`;
+      this.date.seconds = `${this.dateTime.getSeconds()}`;
+    }
+  }
+
+  static formatDate(date: Date): string {
+    const year = `${date.getFullYear()}`;
+    const month = `${date.getMonth() + 1}`.padStart(2, "0");
+    const day = `${date.getDate()}`.padStart(2, "0");
+    return `${year}.${month}.${day}`;
+  }
+
+  getDateYearMonthDay(): string {
+    return `${this.date.year}.${this.date.month.padStart(2, "0")}.${this.date.day.padStart(2, "0")}`;
+  }
+
+  getDateMonth(month: number): string {
+    const newDate = new Date(this.dateTime);
+    newDate.setMonth(newDate.getMonth() + month);
+    return GetDateNow.formatDate(newDate);
+  }
+
+  getDateYear(year: number): string {
+    const newDate = new Date(this.dateTime);
+    newDate.setFullYear(newDate.getFullYear() + year);
+    return GetDateNow.formatDate(newDate);
+  }
+
+  getDateDay(day: number): string {
+    const newDate = new Date(this.dateTime);
+    newDate.setDate(newDate.getDate() + day);
+    return GetDateNow.formatDate(newDate);
+  }
+}
+
+export default GetDateNow;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/mypage-orderlist-fix -> dev

## 🔧 작업 내용
- 마이페이지 기간별 조회페이지에서 필요하여, 드롭다운 컴포넌트를 추가하였습니다.
- 주문 목록 조회 시, 기간 별 조회 기능을 추가하였습니다.
- 주문 목록 요청 API를 하나로 통합하였습니다.
- 주문 목록 페이지의 사소한 디자인을 수정하였습니다.

## 📸 스크린샷
<img width="1191" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/36308113/737dfc22-df15-4dba-a7b5-69bd6f9fa6bd">


## 🔗 관련 이슈
ex) #111

## 💬 참고사항
