### PR TITLE
bug(mypage): 존재하지 않는 주문번호의 URL로 들어갔을 때 버그 수정(#291)

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -96,6 +96,10 @@ const router = createBrowserRouter([
         path: "/manage",
         element: <ManagePage />,
       },
+      {
+        path: "/error",
+        element: <ManagePage />,
+      },
     ],
     errorElement: <ErrorPage />,
   },

--- a/src/containers/mypage/MyOrderDetailContainer.tsx
+++ b/src/containers/mypage/MyOrderDetailContainer.tsx
@@ -9,9 +9,11 @@ import OrderDetailInfo from "@/components/mypage/OrderDetailInfo";
 import getPriceFormat from "@/utils/getPriceFormat";
 import ContainerHeader from "@/components/mypage/ContainerHeader.";
 import cartApi from "@/apis/services/cart";
+import Modal from "@/components/common/Modal";
 
 const MyOrderDetailContainer = () => {
   const [orderDetail, setOrderDetail] = useState<MyOrderItem>();
+  const [openModal, setOenModal] = useState({ isOpen: false, message: "" });
   const navigator = useNavigate();
   const { id } = useParams();
 
@@ -22,6 +24,9 @@ const MyOrderDetailContainer = () => {
         const orderItemList = data.item;
         const orderItem = orderItemList.find((item) => `${item._id}` === `${id}`);
         setOrderDetail(orderItem);
+        if (!orderItem) {
+          setOenModal({ isOpen: true, message: "존재하지 않는 주문번호입니다." });
+        }
       }
     } catch (error) {
       console.error(error);
@@ -42,11 +47,25 @@ const MyOrderDetailContainer = () => {
     }
   };
 
+  const errorPageHandleClick = () => {
+    setOenModal(() => {
+      return { isOpen: false, message: "" };
+    });
+    navigator("/mypage/orders");
+  };
+
   useEffect(() => {
     requestGetMyOrderList();
   }, []);
   return (
     <MyOrderDetailContainerLayer>
+      <ModalWrapper>
+        <Modal isOpen={openModal.isOpen} message={openModal.message}>
+          <ModalButtonWrapper onClick={errorPageHandleClick}>
+            <Button value="확인" size="md" variant="sub" />
+          </ModalButtonWrapper>
+        </Modal>
+      </ModalWrapper>
       <div>
         <ContainerHeader title={`주문 번호 : ${id}`} />
         {orderDetail?.products.map((product, idx) => {
@@ -64,14 +83,14 @@ const MyOrderDetailContainer = () => {
                   <ProductQuantity>{product.quantity}개</ProductQuantity>
                 </ProductInfoDetailWrapper>
               </ProductInfoWrapper>
-              <ButttonsWrapper>
+              <ButtonsWrapper>
                 <ReviewButtonStyle onClick={reviewButtonHandleClick}>
                   <Button value="리뷰 작성" size="sm" variant="point" />
                 </ReviewButtonStyle>
                 <CartButtonStyle onClick={() => cartButtonHandleClick(product)}>
                   <Button value="장바구니 담기" size="sm" variant="sub" />
                 </CartButtonStyle>
-              </ButttonsWrapper>
+              </ButtonsWrapper>
             </OrderDetailItemWrapper>
           );
         })}
@@ -88,7 +107,7 @@ const MyOrderDetailContainerLayer = styled.div`
   flex-direction: column;
   gap: 6rem;
 `;
-const ButttonsWrapper = styled.div`
+const ButtonsWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -141,3 +160,10 @@ const ProductQuantity = styled.span`
 
 const ReviewButtonStyle = styled.div``;
 const CartButtonStyle = styled.div``;
+
+const ModalWrapper = styled.div`
+  font-weight: var(--weight-bold);
+`;
+const ModalButtonWrapper = styled.div`
+  width: 100%;
+`;


### PR DESCRIPTION
## 📤 반영 브랜치
ex) feat/login -> dev

## 🔧 작업 내용
- 사용자의 구매목록 주문 번호중 존재하지 않는 주문 번호를 URL로 직접 입력하여
들어갔을때
모달 창으로 안내 문구 표시 후 주문 내역 페이지로 이동하도록 수정하였습니다.

## 📸 스크린샷
<img width="1130" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/36308113/51dfeb5f-8f1a-4ef0-a1d8-f55d9ad6aeb7">


## 🔗 관련 이슈
#291

## 💬 참고사항
