### PR TITLE
feat(ProductList): 상품 목록 정렬 버튼 기능 구현(#268)

### DIFF
--- a/src/apis/services/products.ts
+++ b/src/apis/services/products.ts
@@ -2,8 +2,9 @@ import { publicInstance } from "../instance";
 import { ResponseProductsList, ResponseProductInfo } from "@/types/products";
 
 interface SortQueryObject {
-  sortBy: "price" | "createdAt" | "buyQuantity"; // 어떤 기준으로 정렬할지
-  sortOrder: 1 | -1; // 어떤 순서로 정렬할지
+  price?: number;
+  createdAt?: number;
+  buyQuantity?: number;
 }
 
 interface FilterQueryObject {
@@ -20,7 +21,7 @@ interface RequestSearchProducts {
 }
 
 const getSortQueryString = (sortQueryObject: SortQueryObject) => {
-  return `sort={"${sortQueryObject.sortBy}": ${sortQueryObject.sortOrder}}`;
+  return `sort=${JSON.stringify(sortQueryObject)}`;
 };
 
 const getFilterQueryString = (filterQueryObject: FilterQueryObject) => {

--- a/src/components/product/productlist/ProductSortButtons.tsx
+++ b/src/components/product/productlist/ProductSortButtons.tsx
@@ -1,12 +1,17 @@
 import styled from "styled-components";
+import useQueryParams from "@/hooks/useQueryParams";
 
 interface ProductSortButtonsProps {
   productLength: number;
 }
 const ProductSortButtons = ({ productLength }: ProductSortButtonsProps) => {
-  const changeQueryString = () => {
-    // 쿼리스트링 변경하는 코드
-  };
+  const categoryArray = [
+    { name: "인기순", sortNumber: 0 },
+    { name: "최신순", sortNumber: 1 },
+    { name: "가격낮은순", sortNumber: 2 },
+    { name: "가격높은순", sortNumber: 3 },
+  ];
+  const { toggleSortFilter } = useQueryParams("sortType");
 
   return (
     <CategorySortLayer>
@@ -14,12 +19,11 @@ const ProductSortButtons = ({ productLength }: ProductSortButtonsProps) => {
         <StyledProductCount>전체 {productLength}개</StyledProductCount>
       </li>
       <li>
-        <StyledCategorySortButton onClick={changeQueryString} type="button">
-          인기순
-        </StyledCategorySortButton>
-        <StyledCategorySortButton type="button">최신순</StyledCategorySortButton>
-        <StyledCategorySortButton type="button">낮은가격순</StyledCategorySortButton>
-        <StyledCategorySortButton type="button">높은가격순</StyledCategorySortButton>
+        {categoryArray.map((cate) => (
+          <StyledCategorySortButton key={cate.name} onClick={() => toggleSortFilter(`${cate.sortNumber}`)}>
+            {cate.name}
+          </StyledCategorySortButton>
+        ))}
       </li>
     </CategorySortLayer>
   );

--- a/src/containers/product/ProductSortContainer.tsx
+++ b/src/containers/product/ProductSortContainer.tsx
@@ -19,8 +19,13 @@ const ProductSortContainer = () => {
   const hashTagQuery = searchParams.get("hashTag")?.split(",");
   const isDecafQuery = searchParams.get("isDecaf")?.split(",");
 
+  const sortQuery = searchParams.get("sortType");
+
   type filterObjectType = Partial<Extra>;
   const filterObject: filterObjectType = {};
+
+  type sortObjectType = Partial<Product>;
+  const sortObject: sortObjectType = {};
 
   if (packQuery) {
     filterObject.pack = packQuery;
@@ -38,8 +43,17 @@ const ProductSortContainer = () => {
     filterObject.isDecaf = Boolean(isDecafQuery[0]);
   }
 
-  // const sortOrder = { sortBy: "price", sortOrder: -1 };
-  const getFilteredData = async (filterDataObject?: filterObjectType, sortDataObject?: any) => {
+  if (sortQuery === "0") {
+    sortObject.buyQuantity = 1;
+  } else if (sortQuery === "1") {
+    sortObject.createdAt = "1";
+  } else if (sortQuery === "2") {
+    sortObject.price = 1;
+  } else {
+    sortObject.price = -1;
+  }
+
+  const getFilteredData = async (sortDataObject?: sortObjectType, filterDataObject?: filterObjectType) => {
     try {
       const response = await productsApi.searchProducts({
         sort: sortDataObject,
@@ -53,7 +67,7 @@ const ProductSortContainer = () => {
   };
 
   useEffect(() => {
-    getFilteredData(filterObject);
+    getFilteredData(sortObject, filterObject);
   }, [queryString]);
 
   return (

--- a/src/hooks/useQueryParams.tsx
+++ b/src/hooks/useQueryParams.tsx
@@ -42,11 +42,25 @@ const useQueryParams = (queryKey: string) => {
     }
   };
 
+  const toggleSortFilter = (string: string) => {
+    // queryKey: sortType, string: 1
+    const isExist = searchParams.toString().includes(queryKey);
+
+    if (!isExist) {
+      searchParams.append(queryKey, string);
+      setSearchParams(searchParams);
+    } else {
+      searchParams.delete(queryKey);
+      searchParams.append(queryKey, string);
+      setSearchParams(searchParams);
+    }
+  };
+
   const resetFilter = () => {
     setSearchParams("");
   };
 
-  return { curQueryData, toggleFilter, toggleDecafFilter, resetFilter };
+  return { curQueryData, toggleFilter, toggleDecafFilter, toggleSortFilter, resetFilter };
 };
 
 export default useQueryParams;


### PR DESCRIPTION
상품 목록에서 정렬을 담당하는 필터링 기능을 구현합니다.

## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
- 정렬 버튼 클릭 시 해당하는 쿼리스트링이 주소에 저장되도록 하는 함수를 생성했습니다. (useQueryParams의 toggleSortFilter)
- sortObject라는 이름의 객체를 생성하고, 쿼리스트링에 맞게 key: value를 저장합니다. 
- 쿼리스트링이 변경되면 실행하는 함수의 인자에 sortObject를 인자로 넘깁니다. 
- 받아온 sortObject를 JSON 문자열로 변환하여 api를 요청합니다. 

## 📸 스크린샷
https://github.com/Eurachacha/hanmogeum/assets/117130358/735824e1-0bb2-413a-9819-3d78c2b6235d

## 🔗 관련 이슈
#268 

## 💬 참고사항
쿼리스트링을 index을 기준으로 저장할 경우 추후 요소가 삭제되었을 때 기대한 내용과 다르게 동작할 가능성이 있어 고정값으로 쿼리스트링을 저장하였습니다. 

```tsx
 if (sortQuery === "0") {
    sortObject.buyQuantity = 1;
  } else if (sortQuery === "1") {
    sortObject.createdAt = "1";
  } else if (sortQuery === "2") {
    sortObject.price = 1;
  } else {
    sortObject.price = -1;
  }
```


