### PR TITLE
chore(/types): product 타입에서 shippingFees 제거 (#308)

### DIFF
--- a/src/types/manage.ts
+++ b/src/types/manage.ts
@@ -7,7 +7,6 @@ import { Extra, ProductDetail } from "@/types/products";
 // POST /seller/products
 export interface RequestProductCreate {
   price: number;
-  shippingFees: number;
   show: boolean;
   active: boolean;
   name: string;

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -16,7 +16,6 @@ export interface Product {
   _id: number;
   seller_id: number;
   price: number;
-  shippingFees: number;
   show: boolean;
   active: boolean;
   name: string;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/admin -> dev

## 🔧 작업 내용
shippingFees필드가 없으면 자동으로 배송비가 반영되므로 해당 필드를 제거했습니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
상품등록 api에서 shippingFees 필드를 넣지 않으면 에러가 발생하는 문제가 있습니다.