### PR TITLE
feat(auth): '마이페이지 > 내 정보 수정' 추가인증 확인 로직 추가

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -105,7 +105,7 @@ const router = createBrowserRouter([
       },
       {
         path: "/",
-        element: <ProtectedRoute location="/" modalMessage="잘못된 접근입니다." allowedRoles={["guest"]} />,
+        element: <ProtectedRoute location={-1} modalMessage="이미 로그인된 사용자입니다." allowedRoles={["guest"]} />,
         children: [
           {
             path: "/login",

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -14,12 +14,14 @@ import { AUTH_TOKEN_KEY } from "@/constants/api";
 import { cartState, cartCheckedItemState } from "@/recoil/atoms/cartState";
 // type
 import { CartStorageItem } from "@/types/cart";
+import additionalAuthState from "@/recoil/atoms/additionalAuthState";
 
 interface LoginProps {
   children?: PropsWithChildren;
+  isAdditionalAuth?: boolean;
   redirectAfterLogin: string | number;
 }
-const Login = ({ children, redirectAfterLogin = "/" }: PropsWithChildren<LoginProps>) => {
+const Login = ({ children, isAdditionalAuth = false, redirectAfterLogin = "/" }: PropsWithChildren<LoginProps>) => {
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -28,6 +30,7 @@ const Login = ({ children, redirectAfterLogin = "/" }: PropsWithChildren<LoginPr
   const loginFailMessage = "아이디와 패스워드를 확인해주세요.";
   const [cartStorage, setCartStorage] = useRecoilState(cartState);
   const setCartCheckedItem = useSetRecoilState(cartCheckedItemState);
+  const setAdditionalAuthState = useSetRecoilState(additionalAuthState);
 
   const mergeCartAfterLogin = async () => {
     // 상태 관리 중이던 장바구니 상품을 로그인 유저가 갖고 있던 장바구니와 합치기 요청
@@ -68,6 +71,9 @@ const Login = ({ children, redirectAfterLogin = "/" }: PropsWithChildren<LoginPr
         localStorage.setItem(AUTH_TOKEN_KEY, data.item.token.accessToken);
         localStorage.setItem("refreshToken", data.item.token.refreshToken);
         await mergeCartAfterLogin();
+        if (isAdditionalAuth) {
+          setAdditionalAuthState(true);
+        }
         // Type Guard
         if (typeof redirectAfterLogin === "string") {
           navigate(redirectAfterLogin);

--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -6,9 +6,14 @@ import Modal from "../common/Modal";
 import Button from "../common/Button";
 import { PrivateRouteProps } from "@/types/routeAuthorization";
 
-const ProtectedRoute = ({ allowedRoles, modalMessage, location }: PrivateRouteProps) => {
+const ProtectedRoute = ({
+  allowedRoles,
+  modalMessage,
+  isAdditionalAuthRequired = false,
+  location,
+}: PrivateRouteProps) => {
   const navigate = useNavigate();
-  const isAuthenticatedUser = useAuthorization({ allowedRoles });
+  const isAuthenticatedUser = useAuthorization({ allowedRoles, isAdditionalAuthRequired });
   const [modalOpen, setModalOpen] = useState({ isOpen: false, message: "" });
 
   useEffect(() => {

--- a/src/containers/mypage/MyProfileLoginContainer.tsx
+++ b/src/containers/mypage/MyProfileLoginContainer.tsx
@@ -9,7 +9,7 @@ const MyProfileLoginContainer = () => {
     <>
       <ContainerHeader title="내 정보 변경" />
       <ContentsTitle title="내 정보 변경"></ContentsTitle>
-      <Login redirectAfterLogin="/mypage/profile/modify">
+      <Login isAdditionalAuth redirectAfterLogin="/mypage/profile/modify">
         <ButtonWrapper>
           <Button value="로그인" size="sm" variant="point" />
         </ButtonWrapper>

--- a/src/containers/signUp/SignUpContainer.tsx
+++ b/src/containers/signUp/SignUpContainer.tsx
@@ -131,6 +131,7 @@ const SignUpContainer = () => {
         setIsActiveEmailButton(true);
       }
     } catch (error: unknown) {
+      console.error(error);
       const signupError = error as SignUpErrorType;
       let errorMessage = "";
       if (signupError.response?.status === 409) {

--- a/src/hooks/useAuthorization.ts
+++ b/src/hooks/useAuthorization.ts
@@ -1,14 +1,23 @@
 import { useRecoilValue } from "recoil";
 import { getUserTypeState } from "@/recoil/selectors/loggedInUserSelector";
 import { AuthorizationProps } from "@/types/routeAuthorization";
+import additionalAuthState from "@/recoil/atoms/additionalAuthState";
 
 /**
  * 사용자 권한이 allowedRoles에 충족한지 체크하는 커스텀 훅
  * @param param0 체크할 권한
  * @returns 충족 유/무
  */
-const useAuthorization = ({ allowedRoles }: AuthorizationProps) => {
+const useAuthorization = ({ allowedRoles, isAdditionalAuthRequired = false }: AuthorizationProps) => {
   const userType = useRecoilValue(getUserTypeState);
+  const additionalAuthRequired = useRecoilValue(additionalAuthState);
+
+  if (isAdditionalAuthRequired && isAdditionalAuthRequired === true) {
+    if (additionalAuthRequired === false) {
+      return false;
+    }
+  }
+
   if (allowedRoles.includes("all")) {
     return true;
   }

--- a/src/recoil/atoms/additionalAuthState.ts
+++ b/src/recoil/atoms/additionalAuthState.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const additionalAuthState = atom({
+  key: "additionalAuthState",
+  default: false,
+});
+
+export default additionalAuthState;

--- a/src/types/routeAuthorization.ts
+++ b/src/types/routeAuthorization.ts
@@ -4,9 +4,11 @@ export type RouteAuthType = UserType | "all" | "guest";
 
 export interface AuthorizationProps {
   allowedRoles: RouteAuthType[];
+  isAdditionalAuthRequired?: boolean;
 }
 
 export interface PrivateRouteProps extends AuthorizationProps {
   location: string | number;
   modalMessage?: string;
+  isAdditionalAuthRequired?: boolean;
 }


### PR DESCRIPTION
## 📤 반영 브랜치
feat/route -> dev

## 🔧 작업 내용
- 마이페이지 > 내 정보 수정' 과 같이 추가 인증이 되어야 렌더링 되는 컴포넌트를 위해 상태관리 추가 후 관련 login 컴포넌트와 protectedRoute 옵션을 추가하였습니다.
-  내 정보 변경 시 추가인증 로그인 완료되어야 접근 가능하도록 수정하였습니다.
- 로그인한 사용자가 login, signup 페이지 접근 시 보이는 메시지와 location을 수정하였습니다.

## 📸 스크린샷
`http://localhost:5173/mypage/profile/modify` URL 직접 입력 시 화면

![image](https://github.com/Eurachacha/hanmogeum/assets/36308113/c621b2b1-a418-4593-98f4-83556d5cd88a)


## 🔗 관련 이슈
#287

## 💬 참고사항
