### PR TITLE
feat(admin): 상품목록 불러오기(#330)

### DIFF
--- a/src/components/admin/ProductList.tsx
+++ b/src/components/admin/ProductList.tsx
@@ -1,0 +1,40 @@
+import { List, Datagrid, TextField, FunctionField } from "react-admin";
+import { useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { Product } from "@/types/products";
+import { flattenCodeState } from "@/recoil/atoms/codeState";
+import { FlattenData } from "@/types/code";
+import getPriceFormat from "@/utils/getPriceFormat";
+
+const getExtraString = (states: FlattenData, stateCode: string) => {
+  return states[stateCode].value;
+};
+
+const ProductList = () => {
+  const flattenCodes = useRecoilValue(flattenCodeState);
+
+  const { authorId } = useParams();
+  return (
+    <List resource="products" filter={{ authorId }}>
+      <Datagrid rowClick="edit">
+        <TextField source="_id" label="상품ID" sortable={false} />
+        <TextField source="name" label="상품명" sortable={false} />
+        <FunctionField
+          label="판매가격"
+          render={(record: Product) => getPriceFormat({ price: record.price })}
+          sortable
+        />
+        <FunctionField label="재고" render={(record: Product) => record.quantity - record.buyQuantity} sortable />
+        <FunctionField
+          label="포장형태"
+          render={(record: Product) => {
+            return getExtraString(flattenCodes, record.extra.pack[0]);
+          }}
+        />
+        <TextField source="buyQuantity" label="누적주문수" sortable />
+      </Datagrid>
+    </List>
+  );
+};
+
+export default ProductList;

--- a/src/pages/ManagePage.tsx
+++ b/src/pages/ManagePage.tsx
@@ -3,6 +3,7 @@ import { useSetRecoilState } from "recoil";
 import { useEffect } from "react";
 import dataProvider from "@/apis/services/admin/dataProvider";
 import OrderList from "@/components/admin/OrderList";
+import ProductList from "@/components/admin/ProductList";
 import { flattenCodeState, nestedCodeState } from "@/recoil/atoms/codeState";
 import codeApi from "@/apis/services/code";
 
@@ -27,6 +28,7 @@ export const ManagePage = () => {
   return (
     <Admin basename="/manage" dataProvider={dataProvider}>
       <Resource name="orders" list={OrderList} />
+      <Resource name="products" list={ProductList} />
     </Admin>
   );
 };


### PR DESCRIPTION
## 📤 반영 브랜치
feat/admin -> dev

## 🔧 작업 내용
- seller의 상품관리를 위한 탭과 상품목록을 출력했습니다.

## 📸 스크린샷
<img width="1127" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/ffb71df4-52c3-49a6-85a9-f79fd1d56184">

## 🔗 관련 이슈

## 💬 참고사항
