### PR TITLE
fix(admin): getCodeValue.ts 내부 훅 제거(#331)

### DIFF
--- a/src/components/admin/OrderList.tsx
+++ b/src/components/admin/OrderList.tsx
@@ -1,15 +1,19 @@
 import { List, Datagrid, TextField, FunctionField, DateField } from "react-admin";
+import { useRecoilValue } from "recoil";
 import { OrderDetail } from "@/types/orders";
 import getPriceFormat from "@/utils/getPriceFormat";
 import getCodeValue from "@/utils/getCodeValue";
+import { flattenCodeState } from "@/recoil/atoms/codeState";
 
 const OrderList = () => {
+  const flattenCodes = useRecoilValue(flattenCodeState);
+
   return (
     <List resource="orders">
       <Datagrid rowClick="edit">
         <TextField source="_id" label="주문번호" sortable={false} />
         <TextField source="user_id" label="주문자ID" sortable={false} />
-        <FunctionField label="배송상태" render={(record: OrderDetail) => getCodeValue(record.state)} />
+        <FunctionField label="배송상태" render={(record: OrderDetail) => getCodeValue(flattenCodes, record.state)} />
         <FunctionField
           label="배송지"
           render={(record: OrderDetail) => {

--- a/src/components/admin/ProductList.tsx
+++ b/src/components/admin/ProductList.tsx
@@ -1,11 +1,15 @@
 import { List, Datagrid, TextField, FunctionField } from "react-admin";
 import { useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 import { Product } from "@/types/products";
 import getCodeValue from "@/utils/getCodeValue";
 import getPriceFormat from "@/utils/getPriceFormat";
+import { flattenCodeState } from "@/recoil/atoms/codeState";
 
 const ProductList = () => {
+  const flattenCodes = useRecoilValue(flattenCodeState);
   const { authorId } = useParams();
+
   return (
     <List resource="products" filter={{ authorId }}>
       <Datagrid rowClick="edit">
@@ -20,7 +24,7 @@ const ProductList = () => {
         <FunctionField
           label="포장형태"
           render={(record: Product) => {
-            return getCodeValue(record.extra.pack[0]);
+            return getCodeValue(flattenCodes, record.extra.pack[0]);
           }}
         />
         <TextField source="buyQuantity" label="누적주문수" sortable />

--- a/src/utils/getCodeValue.ts
+++ b/src/utils/getCodeValue.ts
@@ -1,9 +1,7 @@
-import { useRecoilValue } from "recoil";
-import { flattenCodeState } from "@/recoil/atoms/codeState";
+import { FlattenData } from "@/types/code";
 
-const getCodeValue = (stateCode: string) => {
-  const flattenCodes = useRecoilValue(flattenCodeState);
-  return flattenCodes[stateCode].value;
+const getCodeValue = (codes: FlattenData, stateCode: string) => {
+  return codes[stateCode].value;
 };
 
 export default getCodeValue;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/admin -> dev

## 🔧 작업 내용
- getCodeValue.ts 내부에서 훅을 사용해 발생하는 경고를 해결하기 위해 훅을 제거했습니다.
- 함수를 사용하는 곳에서 훅을 사용해 flattenData를 전달해야 합니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
