### PR TITLE
fix(ProductList): 상품 아이템 개수 props로 수정(#321)

### DIFF
--- a/src/components/product/productlist/ProductItemList.tsx
+++ b/src/components/product/productlist/ProductItemList.tsx
@@ -5,11 +5,12 @@ import EmptyMessage from "@/components/common/EmptyMessage";
 
 interface ProductItemListProps {
   products: Product[];
+  listCount: number;
 }
 
-const ProductItemList = ({ products }: ProductItemListProps) => {
+const ProductItemList = ({ products, listCount }: ProductItemListProps) => {
   return products.length ? (
-    <ProductItemListLayer>
+    <ProductItemListLayer $listCount={listCount}>
       {products &&
         products.map((product, idx) => {
           const key = idx.toString();
@@ -23,8 +24,8 @@ const ProductItemList = ({ products }: ProductItemListProps) => {
 
 export default ProductItemList;
 
-const ProductItemListLayer = styled.div`
+const ProductItemListLayer = styled.div<{ $listCount: number }>`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(${(props) => props.$listCount}, 1fr);
   gap: 20px;
 `;

--- a/src/containers/product/ProductSortContainer.tsx
+++ b/src/containers/product/ProductSortContainer.tsx
@@ -73,7 +73,7 @@ const ProductSortContainer = () => {
   return (
     <ProductSortContainerLayer>
       <ProductSortButtons productLength={products.length} />
-      <ProductItemList products={products} />
+      <ProductItemList products={products} listCount={3} />
     </ProductSortContainerLayer>
   );
 };


### PR DESCRIPTION
## 📤 반영 브랜치
feat/main-products -> dev

## 🔧 작업 내용
상품 목록 리스트에서 정렬되는 아이템 개수를 사용하는 쪽에서 props로 설정할 수 있도록 코드를 수정하였습니다.

## 📸 스크린샷
**사용 예시1**
<img width="797" alt="이슈321 사용1" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/77152f30-a4ed-407e-b12b-361c997c7203">

**사용예시2**
<img width="1287" alt="이슈321 사용2" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/69b9adf2-531d-42e9-b4d1-00079d2856bf">

## 🔗 관련 이슈
#321

## 💬 참고사항
