### PR TITLE
feat(MainPage): 메인 페이지 product 컴포넌트 생성(#247)

### DIFF
--- a/src/components/main/MainProductsList.tsx
+++ b/src/components/main/MainProductsList.tsx
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+import { Product } from "@/types/products";
+import ProductItemList from "../product/productlist/ProductItemList";
+
+interface MainProductsListProps {
+  products: Product[]; // DB장바구니 state
+  title: string;
+  content: string;
+}
+
+const MainProductsList = ({ products, title, content }: MainProductsListProps) => {
+  return (
+    <MainProductsListLayer>
+      <StyledMainProductsListText>
+        <h2>{title}</h2>
+        <p>{content}</p>
+      </StyledMainProductsListText>
+
+      <ProductItemList products={products} listCount={4} />
+    </MainProductsListLayer>
+  );
+};
+export default MainProductsList;
+
+const MainProductsListLayer = styled.div`
+  margin: 80px 0;
+`;
+
+const StyledMainProductsListText = styled.div`
+  /* text-align: center; */
+  padding: 18px 0;
+
+  h2 {
+    font-size: 2.8rem;
+    font-weight: var(--weight-bold);
+    margin-bottom: 10px;
+  }
+  p {
+    color: var(--color-gray-300);
+    font-size: 1.4rem;
+  }
+`;

--- a/src/containers/main/MainContainer.tsx
+++ b/src/containers/main/MainContainer.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import productsApi from "@/apis/services/products";
+import GatherTeaType from "@/components/main/GatherTeaType";
+import Slider from "@/components/main/Slider";
+import { Product } from "@/types/products";
+import BestProducts from "@/components/main/MainProductsList";
+import Banner from "@/components/main/Banner";
+
+const MainContainer = () => {
+  const [newProducts, setNewProducts] = useState<Product[]>([]);
+  const [bestProducts, setBestProducts] = useState<Product[]>([]);
+
+  const getNewProducts = async () => {
+    try {
+      const response = await productsApi.getProductByIsBest();
+      setNewProducts(response.data.item.slice(0, 4));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const getBestProducts = async () => {
+    try {
+      const response = await productsApi.getProductByIsNew();
+      setBestProducts(response.data.item.slice(0, 4));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getNewProducts();
+    getBestProducts();
+  }, []);
+  return (
+    <>
+      <Slider />
+      {newProducts && (
+        <BestProducts products={newProducts} title="NEW ARRIVALS" content="한모금 상품을 가장 먼저 만나보세요!" />
+      )}
+      <Banner />
+      {bestProducts && (
+        <BestProducts products={bestProducts} title="BEST PRODUCTS" content="가장 많이 찾으신 상품입니다." />
+      )}
+      <GatherTeaType />
+    </>
+  );
+};
+
+export default MainContainer;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/main-products -> dev

## 🔧 작업 내용
메인 페이지에 들어갈 ProductsList 컴포넌트를 생성했습니다.
캐러셀 기능은 배너 캐러셀이 완성된 뒤 추가할 예정입니다. 

## 📸 스크린샷
<img width="1221" alt="메인 상품 리스트" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/5859076f-fdb7-4225-b14f-3f8ba233c7d6">

## 🔗 관련 이슈
#247 

## 💬 참고사항
**사용방법**
props로 products에는 type Product[] 형태의 데이터, title에는 메인 타이틀, content는 하단 타이틀 내용을 string 형태로 넣습니다. 

예시
```tsx
<MainProductsList products={newProducts} title="NEW ARRIVALS" content="한모금 상품을 가장 먼저 만나보세요!" />
```