### PR TITLE
feat(admin): OrderEdit 컴포넌트 구현(#359)

### DIFF
--- a/src/components/admin/OrderEdit.tsx
+++ b/src/components/admin/OrderEdit.tsx
@@ -1,0 +1,71 @@
+import {
+  Edit,
+  SimpleForm,
+  Datagrid,
+  TextField,
+  DateField,
+  Labeled,
+  SelectInput,
+  FunctionField,
+  ArrayField,
+  FieldTitle,
+} from "react-admin";
+import { useRecoilValue } from "recoil";
+import { OrderStateCode } from "@/types/code";
+import { nestedCodeState } from "@/recoil/atoms/codeState";
+import { OrderDetail } from "@/types/orders";
+
+const OrderEdit = () => {
+  const nestedCodes = useRecoilValue(nestedCodeState);
+  const orderStateChoices = nestedCodes?.orderState.codes.map((codeObj: OrderStateCode) => {
+    return { id: codeObj.code, name: codeObj.value };
+  });
+
+  return (
+    <Edit>
+      <SimpleForm>
+        <Labeled source="주문번호">
+          <TextField source="_id" />
+        </Labeled>
+        <Labeled source="주문자 ID">
+          <TextField source="user_id" label="주문자 ID" />
+        </Labeled>
+        <Labeled source="주문일시">
+          <DateField source="createdAt" showTime />
+        </Labeled>
+        <FieldTitle label="배송정보"></FieldTitle>
+        <Labeled source="받는사람 이름">
+          <TextField source="shippingInfo.name" />
+        </Labeled>
+        <Labeled source="받는사람 연락처">
+          <TextField source="shippingInfo.phone" />
+        </Labeled>
+        <Labeled source="받는 곳 주소">
+          <TextField source="shippingInfo.address.value" />
+        </Labeled>
+        <SelectInput source="state" label="배송상태" choices={orderStateChoices} />
+        <ArrayField source="products" textAlign="center">
+          <Datagrid bulkActionButtons={false}>
+            <TextField source="_id" label="상품ID" />
+            <TextField source="name" label="상품명" />
+            <TextField source="quantity" label="주문수량" />
+          </Datagrid>
+        </ArrayField>
+        <FieldTitle label="금액정보"></FieldTitle>
+        <Labeled source="상품금액">
+          <TextField source="cost.products" />
+        </Labeled>
+        <Labeled source="배송비">
+          <FunctionField
+            render={(record: OrderDetail) => record.cost.shippingFees - record.cost.discount.shippingFees}
+          />
+        </Labeled>
+        <Labeled source="총 결제 금액">
+          <TextField source="cost.total" />
+        </Labeled>
+      </SimpleForm>
+    </Edit>
+  );
+};
+
+export default OrderEdit;

--- a/src/pages/ManagePage.tsx
+++ b/src/pages/ManagePage.tsx
@@ -1,11 +1,11 @@
 import { Admin, Resource } from "react-admin";
 import { useSetRecoilState } from "recoil";
 import { useEffect } from "react";
-import dataProvider from "@/apis/services/admin/dataProvider";
 import OrderList from "@/components/admin/OrderList";
 import ProductList from "@/components/admin/ProductList";
 import { flattenCodeState, nestedCodeState } from "@/recoil/atoms/codeState";
 import codeApi from "@/apis/services/code";
+import OrderEdit from "@/components/admin/OrderEdit";
 import sellerDataProvider from "@/apis/services/admin/sellerDataProvider";
 
 export const ManagePage = () => {
@@ -28,7 +28,7 @@ export const ManagePage = () => {
 
   return (
     <Admin basename="/seller" dataProvider={sellerDataProvider}>
-      <Resource name="orders" list={OrderList} />
+      <Resource name="orders" list={OrderList} edit={OrderEdit} />
       <Resource name="products" list={ProductList} />
     </Admin>
   );


### PR DESCRIPTION
## 📤 반영 브랜치
feat/login -> dev

## 🔧 작업 내용
- Order세부정보와 배송상태수정을 할 수 있는 OrderEdit컴포넌트를 구현했습니다.

## 📸 스크린샷
<img width="300" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/de82bfaa-b023-4890-b755-8f53d7a754f7">

## 🔗 관련 이슈

## 💬 참고사항
스타일링 작업이 되지 않고 기능만 있는 상태입니다.
