### PR TITLE
feat(orderDetail): 주문 상세페이지 주문 취소 버튼 추가(#349, #297, #293)

### DIFF
--- a/src/apis/services/mypage.ts
+++ b/src/apis/services/mypage.ts
@@ -1,3 +1,4 @@
+import ORDER_STATE from "@/constants/code";
 import { privateInstance } from "../instance";
 import { ResponseDataMyOrderDetail, ResponseDataMyOrderList, getMyPageOrderListProps } from "@/types/myPage";
 
@@ -12,6 +13,6 @@ const myPageApi = {
   },
   getMyPageOrderDetail: (id: number | string) => privateInstance.get<ResponseDataMyOrderDetail>(`/orders/${id}`),
   patchMyPageOrderShippingCancel: (id: number | string) =>
-    privateInstance.patch<ResponseDataMyOrderDetail>(`/orders/${id}`, { state: "OS100" }),
+    privateInstance.patch<ResponseDataMyOrderDetail>(`/orders/${id}`, { state: ORDER_STATE.SHIPPING_CANCEL.CODE }),
 };
 export default myPageApi;

--- a/src/apis/services/mypage.ts
+++ b/src/apis/services/mypage.ts
@@ -1,5 +1,5 @@
 import { privateInstance } from "../instance";
-import { ResponseDataMyOrderList, getMyPageOrderListProps } from "@/types/myPage";
+import { ResponseDataMyOrderDetail, ResponseDataMyOrderList, getMyPageOrderListProps } from "@/types/myPage";
 
 const myPageApi = {
   getMyPageOrderList: ({ state, createdAt }: getMyPageOrderListProps) => {
@@ -10,5 +10,8 @@ const myPageApi = {
       baseURL + (shippingCodeFilter || periodFilter ? `custom={${[shippingCodeFilter, periodFilter].join("")}}` : "");
     return privateInstance.get<ResponseDataMyOrderList>(resultURL);
   },
+  getMyPageOrderDetail: (id: number | string) => privateInstance.get<ResponseDataMyOrderDetail>(`/orders/${id}`),
+  patchMyPageOrderShippingCancel: (id: number | string) =>
+    privateInstance.patch<ResponseDataMyOrderDetail>(`/orders/${id}`, { state: "OS100" }),
 };
 export default myPageApi;

--- a/src/apis/services/orders.ts
+++ b/src/apis/services/orders.ts
@@ -1,3 +1,4 @@
+import ORDER_STATE from "@/constants/code";
 import { privateInstance, publicInstance } from "../instance";
 import { RequestCheckStocks, RequestCreateOrder, ResponseCreateOrder, ResponseGetOrderList } from "@/types/orders";
 
@@ -7,7 +8,7 @@ const ordersApi = {
     publicInstance.post<ResponseCreateOrder>("/orders", { ...data, dryRun: true }),
   // POST /orders
   createOrder: (data: RequestCreateOrder) =>
-    privateInstance.post<ResponseCreateOrder>("/orders", { ...data, state: "OS030" }),
+    privateInstance.post<ResponseCreateOrder>("/orders", { ...data, state: ORDER_STATE.SHIPPING_PREPARING.CODE }),
   // GET /orders
   getOrderList: () => privateInstance.get<ResponseGetOrderList>("/orders"),
 };

--- a/src/components/MypageDashBoard/WidgetShipping.tsx
+++ b/src/components/MypageDashBoard/WidgetShipping.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import myPageApi from "@/apis/services/mypage";
+import ORDER_STATE from "@/constants/code";
 
 const WidgetShipping = () => {
   // TODO: 리액트 쿼리로 수정
   const [shippingInfo, setShippingInfo] = useState([
     {
-      name: "배송준비중",
+      name: ORDER_STATE.SHIPPING_PREPARING.NAME,
       value: 0,
-      code: "OS030",
+      code: ORDER_STATE.SHIPPING_PREPARING.CODE,
     },
-    { name: "배송중", value: 0, code: "OS035" },
-    { name: "배송완료", value: 0, code: "OS040" },
+    { name: ORDER_STATE.SHIPPING_PROGRESS.NAME, value: 0, code: ORDER_STATE.SHIPPING_PROGRESS.CODE },
+    { name: ORDER_STATE.SHIPPING_FINISH.NAME, value: 0, code: ORDER_STATE.SHIPPING_FINISH.CODE },
   ]);
   const getShippingData = async () => {
     try {

--- a/src/constants/code.ts
+++ b/src/constants/code.ts
@@ -1,0 +1,20 @@
+const ORDER_STATE = {
+  SHIPPING_CANCEL: {
+    CODE: "OS100",
+    NAME: "주문 취소",
+  },
+  SHIPPING_PREPARING: {
+    CODE: "OS030",
+    NAME: "배송 준비중",
+  },
+  SHIPPING_PROGRESS: {
+    CODE: "OS035",
+    NAME: "배송중",
+  },
+  SHIPPING_FINISH: {
+    CODE: "OS040",
+    NAME: "배송 완료",
+  },
+};
+
+export default ORDER_STATE;

--- a/src/containers/mypage/MyOrderListContainer.tsx
+++ b/src/containers/mypage/MyOrderListContainer.tsx
@@ -34,8 +34,11 @@ const MyOrderListContainer = () => {
   const flattenCodeDataState: FlattenData = useRecoilValue(flattenCodeState);
 
   const getFilterStartAndEndDate = () => {
-    const getDateNow = new GetDateNow();
-    const endDate = getDateNow.getDateYearMonthDay() || "";
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const getDateNow = new GetDateNow(new Date());
+
+    const endDate = GetDateNow.formatDate(tomorrow) || "";
     let startDate = "";
     if (dropDownData[dropDownIdx].type === "month") {
       startDate = getDateNow.getDateMonth(dropDownData[dropDownIdx].typeValue);

--- a/src/types/myPage.ts
+++ b/src/types/myPage.ts
@@ -6,6 +6,11 @@ export interface ResponseDataMyOrderList {
   item: MyOrderItem[] | [];
 }
 
+export interface ResponseDataMyOrderDetail {
+  ok: number;
+  item: MyOrderItem;
+}
+
 export interface MyOrderItem {
   _id: number;
   user_id: number;

--- a/src/utils/getDateNow.ts
+++ b/src/utils/getDateNow.ts
@@ -9,8 +9,8 @@ class GetDateNow {
 
   date = { year: "", month: "", day: "", hours: "", minutes: "", seconds: "" };
 
-  constructor() {
-    this.dateTime = new Date();
+  constructor(date: Date) {
+    this.dateTime = date;
     this.#setDate();
   }
 


### PR DESCRIPTION
## 📤 반영 브랜치
feat/mypage-orderdetail-cancle -> dev

## 🔧 작업 내용
- 주문 조회 기간의 마지막 일인 경우 조회에서 제거되어 조회 기간을 수정하였습니다.
- 백엔드api 개발이 완료되어, 주문 상세페이지 api를 추가하였습니다.
- 배송 코드에 따라 분기되는 로직에서 코드를 상수로 관리하도록 수정하였습니다.
- 주문 상세 페이지에서 주문 취소 버튼 로직을 추가하였습니다.

## 📸 스크린샷

## 🔗 관련 이슈
#349, #297, #293

## 💬 참고사항
관련 이슈에 있는 사항이 수정되었습니다.