### PR TITLE
bug(widgetShipping): 배송조회 위젯에서 사용하는 api 요청 필터 수정(#370)

### DIFF
--- a/src/apis/services/mypage.ts
+++ b/src/apis/services/mypage.ts
@@ -5,10 +5,11 @@ import { ResponseDataMyOrderDetail, ResponseDataMyOrderList, getMyPageOrderListP
 const myPageApi = {
   getMyPageOrderList: ({ state, createdAt }: getMyPageOrderListProps) => {
     const baseURL = "/orders?";
-    const shippingCodeFilter = state ? `"state":"${state}"` : ``;
-    const periodFilter = createdAt ? `"createdAt":{"$gte":"${createdAt.startDate}","$lt":"${createdAt.endDate}"}` : "";
-    const resultURL =
-      baseURL + (shippingCodeFilter || periodFilter ? `custom={${[shippingCodeFilter, periodFilter].join("")}}` : "");
+    const filterList = [];
+    if (state) filterList.push(`"state":"${state}"`);
+    if (createdAt) filterList.push(`"createdAt":{"$gte":"${createdAt.startDate}","$lt":"${createdAt.endDate}"}`);
+
+    const resultURL = baseURL + (filterList.length ? `custom={${filterList.join(",")}}` : "");
     return privateInstance.get<ResponseDataMyOrderList>(resultURL);
   },
   getMyPageOrderDetail: (id: number | string) => privateInstance.get<ResponseDataMyOrderDetail>(`/orders/${id}`),

--- a/src/components/MypageDashBoard/WidgetShipping.tsx
+++ b/src/components/MypageDashBoard/WidgetShipping.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import styled from "styled-components";
 import myPageApi from "@/apis/services/mypage";
 import ORDER_STATE from "@/constants/code";
+import GetDateNow from "@/utils/getDateNow";
 
 const WidgetShipping = () => {
   // TODO: 리액트 쿼리로 수정
@@ -16,9 +17,33 @@ const WidgetShipping = () => {
   ]);
   const getShippingData = async () => {
     try {
-      const response1 = await myPageApi.getMyPageOrderList({ state: shippingInfo[0].code });
-      const response2 = await myPageApi.getMyPageOrderList({ state: shippingInfo[1].code });
-      const response3 = await myPageApi.getMyPageOrderList({ state: shippingInfo[2].code });
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const getDateNow = new GetDateNow(new Date());
+      const endDate = GetDateNow.formatDate(tomorrow) || "";
+      const startDate = getDateNow.getDateYear(-3);
+
+      const response1 = await myPageApi.getMyPageOrderList({
+        createdAt: {
+          startDate,
+          endDate,
+        },
+        state: shippingInfo[0].code,
+      });
+      const response2 = await myPageApi.getMyPageOrderList({
+        createdAt: {
+          startDate,
+          endDate,
+        },
+        state: shippingInfo[1].code,
+      });
+      const response3 = await myPageApi.getMyPageOrderList({
+        createdAt: {
+          startDate,
+          endDate,
+        },
+        state: shippingInfo[2].code,
+      });
       const updatedState = { ...shippingInfo };
       updatedState[0].value = response1.data.item.length;
       updatedState[1].value = response2.data.item.length;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/mypage-order-widget-bug -> dev

## 🔧 작업 내용
- 마이페이지의 배송/조회 위젯에서 최대 3년까지의 배송만 확인 가능하도록 수정하였습니다.

## 📸 스크린샷

## 🔗 관련 이슈
#370

## 💬 참고사항
