### PR TITLE
fix(ProductList): 상품 내 code 데이터 value 변경(#209)

### DIFF
--- a/src/components/product/productlist/ProductItem.tsx
+++ b/src/components/product/productlist/ProductItem.tsx
@@ -1,8 +1,10 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
+import { useEffect } from "react";
 import ProductItemLabel from "./ProductItemLabel";
 import { Product } from "@/types/products";
+import { flattenCodeState } from "@/recoil/atoms/codeState";
 
 interface ProductItemProps {
   product: Product;
@@ -10,6 +12,13 @@ interface ProductItemProps {
 
 const ProductItem = ({ product }: ProductItemProps) => {
   const navigate = useNavigate();
+  const flattenCodes = useRecoilValue(flattenCodeState);
+  const teaTypeCode = product.extra.teaType.toString();
+
+  const hashTagCode = product.extra.hashTag.map((item) => `#${flattenCodes[item].value}`);
+  useEffect(() => {
+    console.log(hashTagCode);
+  }, []);
 
   return (
     <ProductItemLayer onClick={() => navigate(`/products/${product._id}`)}>
@@ -46,7 +55,7 @@ const ProductItem = ({ product }: ProductItemProps) => {
       <ProductItemContentWrapper>
         <ul>
           <StyledTeaType>
-            <p>{product.extra.teaType}</p>
+            <p>{flattenCodes[teaTypeCode].value}</p>
           </StyledTeaType>
           <StyledName>
             <h3>{product.name}</h3>
@@ -56,7 +65,7 @@ const ProductItem = ({ product }: ProductItemProps) => {
           </StyledPrice>
 
           <StyledHashTag>
-            <p>{product.extra.hashTag}</p>
+            <p>{hashTagCode}</p>
           </StyledHashTag>
         </ul>
       </ProductItemContentWrapper>


### PR DESCRIPTION
## 📤 반영 브랜치
feat/main-products -> dev

## 🔧 작업 내용
상품 아이템 컴포넌트 내 code로 되어 있던 teatype과 hashtag 데이터를 recoil에 저장돼있던 flattenCodeState를 사용해 변경하였습니다.

## 📸 스크린샷
<img width="249" alt="이슈209 code값 변경" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/9c9aff7f-585d-4872-b325-404d4d6295ce">


## 🔗 관련 이슈
#209 

## 💬 참고사항
