### PR TITLE
fix(cart): 장바구니 사진깨짐오류 해결(#372)

### DIFF
--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -110,7 +110,12 @@ const CartItem = ({ setCartData, handleDeleteItem, data, idx }: CartItemProps) =
             {quantityInput > 0 && checkedItems.includes(data.product._id) ? <CheckedBoxIcon /> : <UncheckedBoxIcon />}
           </CheckedBox>
           <ImageWrapper>
-            <img src={data.product.image} alt={data.product.name} width="100%" height="100%" />
+            <img
+              src={`${import.meta.env.VITE_API_BASE_URL}${data.product.image.url}`}
+              alt={data.product.name}
+              width="100%"
+              height="100%"
+            />
           </ImageWrapper>
           <ProductTitle>{data.product.name}</ProductTitle>
         </CartItemLeft>


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
- image타입 변화로 사진이 깨졌던 오류를 해결했습니다.

## 📸 스크린샷
<img width="932" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/3e447802-8263-4187-9adb-11b99105e2d2">

## 🔗 관련 이슈

## 💬 참고사항
