### PR TITLE
feat(cart): 장바구니 페이지 재고 안내 및 재고반영안내메시지 출력(#403)

### DIFF
--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -145,8 +145,8 @@ const CartItem = ({ setCartData, handleDeleteItem, data, idx }: CartItemProps) =
               <CounterButton handleQuantity={() => handleQuantityInput("plus")}>+</CounterButton>
             </CounterLayer>
             <Price>{cartItemPrice.toLocaleString()}원</Price>
-            {updated ? <p>재고반영됨</p> : null}
           </CountPrice>
+          {updated ? <InfoMessage>재고 부족으로 최대 구매 가능 수량이 반영되었습니다.</InfoMessage> : null}
           <CancelIconWrapper
             style={{ width: 20, height: 20 }}
             onClick={() => handleDeleteItem((data as CartItemType)._id, data.product._id)}
@@ -209,6 +209,8 @@ const CartItemRight = styled.div`
   justify-content: space-between;
   align-items: center;
   flex: 1 0 0;
+
+  position: relative;
 `;
 
 const CountPrice = styled.div`
@@ -258,6 +260,15 @@ const Price = styled.p`
   text-align: right;
   margin: 0 1rem;
   min-width: 10rem;
+`;
+
+const InfoMessage = styled.p`
+  width: max-content;
+  font-size: 1.2rem;
+  color: var(--color-red);
+  position: absolute;
+  top: 44px;
+  right: 130px;
 `;
 
 const CancelIconWrapper = styled.div`

--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -130,6 +130,13 @@ const CartItem = ({ setCartData, handleDeleteItem, data, idx }: CartItemProps) =
         </CartItemLeft>
         <CartItemRight>
           <CountPrice>
+            <StockInfo>
+              재고:{" "}
+              {user
+                ? (data as CartItemType).product.quantity - (data as CartItemType).product.buyQuantity
+                : (data as CartStorageItem).stock}
+              개
+            </StockInfo>
             <CounterLayer>
               <CounterButton handleQuantity={() => handleQuantityInput("minus")}>-</CounterButton>
               <QuantityWrapper
@@ -238,6 +245,16 @@ const CounterLayer = styled.div`
   & input[type="number"] {
     -moz-appearance: textfield;
   }
+`;
+
+const StockInfo = styled.p`
+  color: var(--color-gray-300);
+  min-width: 100px;
+  font-size: 1.2rem;
+  text-align: center;
+  position: absolute;
+  top: -15px;
+  right: calc(-208-(100vw)) px;
 `;
 
 const QuantityWrapper = styled.input`


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
- 카운터 상단에 재고: n개 문구 출력
- 수량 자동반영 시 안내문구 출력

## 📸 스크린샷
<img width="911" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/ccf7a9bf-25f2-48f2-b41b-3c9ba77f725f">

## 🔗 관련 이슈

## 💬 참고사항
