### PR TITLE
fix(cart): 주문후 장바구니상품수 헤더반영 오류 해결(#410)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -42,6 +42,7 @@ const Header = () => {
       setIsLogin(false);
     }
   }, [user]);
+
   useEffect(() => {
     setCartCount(cartStorage.length);
   }, [cartStorage]);


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
- `type: "cart"`필드가 있는 주문 후에 cartStorage에 cart정보를 받아와 새롭게 저장합니다.
- 헤더에서 cartStorage변화를 감지해 카운트넘버가 수정됩니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
