### PR TITLE
bug(Mypage, Header, Footer): 간단한 버그/마크업 수정

### DIFF
--- a/src/components/MypageDashBoard/WidgetMyInfo.tsx
+++ b/src/components/MypageDashBoard/WidgetMyInfo.tsx
@@ -34,6 +34,7 @@ const WidgetMyInfo = () => {
 const DashBardMyInfoLayout = styled.div`
   align-items: center;
   display: flex;
+  min-width: 24rem;
   gap: 2rem;
 `;
 const ContentsWrapper = styled.div`

--- a/src/components/MypageDashBoard/WidgetTodayTea.tsx
+++ b/src/components/MypageDashBoard/WidgetTodayTea.tsx
@@ -83,6 +83,7 @@ const WidgetTodayTeaLayer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   gap: 1rem;
+  min-width: 26rem;
   cursor: pointer;
 `;
 

--- a/src/components/MypageDashBoard/WidgetTodayTea.tsx
+++ b/src/components/MypageDashBoard/WidgetTodayTea.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useRecoilValue } from "recoil";
+import { useNavigate } from "react-router-dom";
 import productsApi from "@/apis/services/products";
 import { Product } from "@/types/products";
 import getRandomRange from "@/utils/getRandomRange";
@@ -10,12 +11,15 @@ interface TodayTeaItem {
   name: string;
   imgURL: string;
   hashTag: string[];
+  id: number;
 }
 
 const WidgetTodayTea = () => {
   const [bestProducts, setBestProducts] = useState<Product[]>();
   const [todayTea, setTodayTea] = useState<TodayTeaItem>();
+
   const codeData = useRecoilValue(flattenCodeState);
+  const navigate = useNavigate();
   const fetchAndSetBestProducts = async () => {
     try {
       const { data } = await productsApi.getProductByIsBest();
@@ -37,19 +41,27 @@ const WidgetTodayTea = () => {
       name: "",
       imgURL: "",
       hashTag: [],
+      id: 0,
     };
 
     if (bestProducts) {
       newTea.name = bestProducts[randomId]?.name;
       newTea.imgURL = `${import.meta.env.VITE_API_BASE_URL}/${bestProducts[randomId]?.mainImages[0].url}`;
       newTea.hashTag = bestProducts[randomId]?.extra.hashTag;
+      newTea.id = bestProducts[randomId]?._id;
     }
     newTea.hashTag = newTea.hashTag.map((code) => `#${codeData[code]?.value}`);
     setTodayTea(newTea);
   }, [bestProducts]);
 
+  const wigetHandleClick = () => {
+    if (todayTea?.id) {
+      navigate(`/products/${todayTea?.id}`);
+    }
+  };
+
   return (
-    <WidgetTodayTeaLayer>
+    <WidgetTodayTeaLayer onClick={wigetHandleClick}>
       <TitleWrapper>오늘의 추천 차</TitleWrapper>
       <ContentsWrapper>
         <ProductImgStyle>
@@ -71,6 +83,7 @@ const WidgetTodayTeaLayer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   gap: 1rem;
+  cursor: pointer;
 `;
 
 const TitleWrapper = styled.div`

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -33,6 +33,7 @@ const FooterLayer = styled.div`
   font-weight: var(--weight-thin);
   /* overflow: hidden; */
   border-top: 1px solid var(--color-gray-100);
+  margin-top: 10rem;
 `;
 
 const FooterWrapper = styled.span`

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { NavLink, useNavigate, useSearchParams, Link, useLocation } from "react-router-dom";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import IconShoppingCart from "@/assets/icons/shoppingCart_40.svg?react";
-import IconSearchCart from "@/assets/icons/search_24.svg?react";
+// import IconSearchCart from "@/assets/icons/search_24.svg?react"; // 검색 기능
 import { getUserTypeState } from "@/recoil/selectors/loggedInUserSelector";
 import loggedInUserState from "@/recoil/atoms/loggedInUserState";
 import { cartState, cartCheckedItemState } from "@/recoil/atoms/cartState";
@@ -144,10 +144,10 @@ const Header = () => {
             </AdminCategoryStyle>
           )}
         </CategoryWrapper>
-        <SearchWrapper>
+        {/* <SearchWrapper>
           <IconSearchCart />
           <input placeholder="원하는 상품을 검색하세요" type="text" />
-        </SearchWrapper>
+        </SearchWrapper> */}
         <UserControlWrapper>
           {isLogin
             ? userControlList.isLogin.map((userControl) => (
@@ -229,22 +229,23 @@ const AdminCategoryStyle = styled.div`
   border-left: 2px solid var(--color-gray-500);
 `;
 
-const SearchWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border: 1px solid var(--color-sub-500);
-  border-radius: 5px;
-  height: 4rem;
-  svg {
-    padding: 0 0.5rem;
-  }
-  input {
-    min-width: 20rem;
-    outline: none;
-    border: none;
-  }
-`;
+// 검색 기능
+// const SearchWrapper = styled.div`
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   border: 1px solid var(--color-sub-500);
+//   border-radius: 5px;
+//   height: 4rem;
+//   svg {
+//     padding: 0 0.5rem;
+//   }
+//   input {
+//     min-width: 20rem;
+//     outline: none;
+//     border: none;
+//   }
+// `;
 
 const UserControlWrapper = styled.div`
   display: flex;

--- a/src/components/mypage/OrderDetailInfo.tsx
+++ b/src/components/mypage/OrderDetailInfo.tsx
@@ -74,7 +74,7 @@ const OrderDetailInfo = ({ orderData, shippingState }: OrderDetailInfoProps) => 
       </ModalWrapper>
       <UserInfoWrapper>
         <div>
-          <ContainerHeader title="결제 정보" variant="sub" />
+          <ContainerHeader title="주문 정보" variant="sub" />
           <InfoListWrapper>
             {orderInfoList.map((infoData, idx) => {
               const infoWrapperKey = `OrderDetailInfo_InfoWrapper_${idx}`;
@@ -88,7 +88,7 @@ const OrderDetailInfo = ({ orderData, shippingState }: OrderDetailInfoProps) => 
           </InfoListWrapper>
         </div>
         <div>
-          <ContainerHeader title="결제 정보" variant="sub" />
+          <ContainerHeader title="배송 정보" variant="sub" />
           <InfoListWrapper>
             {shippingInfoList.map((infoData, idx) => {
               const infoWrapperKey = `OrderDetailInfo_InfoWrapper_${idx}`;
@@ -105,7 +105,7 @@ const OrderDetailInfo = ({ orderData, shippingState }: OrderDetailInfoProps) => 
           </InfoListWrapper>
         </div>
       </UserInfoWrapper>
-      <div>
+      <PaymentInfoWrapper>
         <ContainerHeader title="결제 정보" variant="sub" />
         <InfoListWrapper>
           {paymentInfoList.map((infoData, idx) => {
@@ -118,7 +118,7 @@ const OrderDetailInfo = ({ orderData, shippingState }: OrderDetailInfoProps) => 
             );
           })}
         </InfoListWrapper>
-      </div>
+      </PaymentInfoWrapper>
       <TotalCostWrapper>
         <span>총 결제 금액</span>
         <span>{getPriceFormat({ price: orderData?.cost?.total })}</span>
@@ -136,6 +136,7 @@ const UserInfoWrapper = styled.div`
   gap: 2rem;
   & > div {
     width: 100%;
+    min-width: 30rem;
   }
 `;
 
@@ -186,5 +187,11 @@ const TotalCostWrapper = styled.div`
   span {
     font-weight: var(--weight-bold);
     font-size: 2.4rem;
+  }
+`;
+
+const PaymentInfoWrapper = styled.div`
+  span:last-child {
+    margin-left: auto;
   }
 `;

--- a/src/components/mypage/OrderDetailInfo.tsx
+++ b/src/components/mypage/OrderDetailInfo.tsx
@@ -37,7 +37,7 @@ const OrderDetailInfo = ({ orderData, shippingState }: OrderDetailInfoProps) => 
   };
 
   const orderInfoList = [
-    { title: "주문번호", value: currentUserInfo?._id || "" },
+    { title: "주문번호", value: orderData?._id || "" },
     { title: "보내는 분", value: currentUserInfo?.name || "" },
     { title: "이메일", value: currentUserInfo?.email || "" },
     { title: "휴대폰 번호", value: autoHyphenPhoneNumber(currentUserInfo?.phone || "") },

--- a/src/containers/mypage/MyOrderDetailContainer.tsx
+++ b/src/containers/mypage/MyOrderDetailContainer.tsx
@@ -12,11 +12,15 @@ import cartApi from "@/apis/services/cart";
 import Modal from "@/components/common/Modal";
 import ORDER_STATE from "@/constants/code";
 
+interface ProductImgWrapperProps {
+  $orderCancelState: boolean;
+}
+
 const MyOrderDetailContainer = () => {
   const [orderDetail, setOrderDetail] = useState<MyOrderItem>();
   const [openModal, setOenModal] = useState({ isOpen: false, message: "" });
   const [shippingState, setShippingState] = useState("");
-  const [buttonDisable, setButtonDisable] = useState(false);
+  const [orderCancelState, setOrderCancelState] = useState(false);
 
   const navigator = useNavigate();
   const { id } = useParams();
@@ -33,10 +37,10 @@ const MyOrderDetailContainer = () => {
     }
   };
 
-  const reviewButtonHandleClick = () => {
-    // TODO: 리뷰 작성 페이지 구현
-    navigator(`/mypage/reviews`);
-  };
+  // const reviewButtonHandleClick = () => {
+  //   // TODO: 리뷰 작성 페이지 구현
+  //   navigator(`/mypage/reviews`);
+  // };
 
   const cartButtonHandleClick = async ({ _id, quantity }: Product) => {
     try {
@@ -59,9 +63,9 @@ const MyOrderDetailContainer = () => {
 
     // 주문 취소
     if (shippingState === ORDER_STATE.SHIPPING_CANCEL.CODE) {
-      setButtonDisable(true);
+      setOrderCancelState(true);
     } else {
-      setButtonDisable(false);
+      setOrderCancelState(false);
     }
   }, [orderDetail]);
 
@@ -83,7 +87,7 @@ const MyOrderDetailContainer = () => {
           const orderItemKey = `MypageLayoutContainer_${product._id}${idx}`;
           return (
             <OrderDetailItemWrapper key={orderItemKey}>
-              <ProductImgWrapper>
+              <ProductImgWrapper $orderCancelState={orderCancelState}>
                 <img src={`${import.meta.env.VITE_API_BASE_URL}/${product.image.url}`} alt={product.name} />
               </ProductImgWrapper>
               <ProductInfoWrapper>
@@ -96,11 +100,13 @@ const MyOrderDetailContainer = () => {
               </ProductInfoWrapper>
 
               <ButtonsWrapper>
+                {/* 
+                // 주문 취소 버튼
                 <ReviewButtonStyle onClick={reviewButtonHandleClick}>
-                  <Button disabled={buttonDisable} value="리뷰 작성" size="sm" variant="point" />
-                </ReviewButtonStyle>
+                  <Button disabled={orderCancelState} value="리뷰 작성" size="sm" variant="point" />
+                </ReviewButtonStyle> */}
                 <CartButtonStyle onClick={() => cartButtonHandleClick(product)}>
-                  <Button disabled={buttonDisable} value="장바구니 담기" size="sm" variant="sub" />
+                  <Button value="장바구니 담기" size="sm" variant="point" />
                 </CartButtonStyle>
               </ButtonsWrapper>
             </OrderDetailItemWrapper>
@@ -118,34 +124,38 @@ const MyOrderDetailContainerLayer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 6rem;
+  overflow: hidden;
 `;
 const ButtonsWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  width: 10rem;
+  min-width: 10rem;
 `;
 
 // 상품 스타일
 const OrderDetailItemWrapper = styled.div`
   display: flex;
   align-items: center;
+  min-width: 30rem;
   gap: 2rem;
   border-bottom: 1px solid var(--color-gray-100);
   padding: 1.6rem;
 `;
 
-const ProductImgWrapper = styled.div`
+const ProductImgWrapper = styled.div<ProductImgWrapperProps>`
   border-radius: 5px;
-  overflow: hidden;
+  opacity: ${(props) => (props.$orderCancelState ? "0.6" : "1")};
   img {
     width: 9rem;
+    height: 9rem;
   }
 `;
 
 const ProductInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  min-width: 14rem;
   gap: 1rem;
   margin-right: auto;
 `;

--- a/src/containers/mypage/MyOrderListContainer.tsx
+++ b/src/containers/mypage/MyOrderListContainer.tsx
@@ -23,7 +23,7 @@ import truncateString from "@/utils/truncateString";
 import getPriceFormat from "@/utils/getPriceFormat";
 
 const MyOrderListContainer = () => {
-  const maxTitleLength = 15;
+  const maxTitleLength = 26;
   const [responseOrderList, setResponseOrderList] = useState<ResponseDataMyOrderList>();
   const [dropDownIdx, setDropDownIdx] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
@@ -74,14 +74,12 @@ const MyOrderListContainer = () => {
   const orderItemToThumbnailData = (orderItem: MyOrderItem) => {
     const getData = new GetDate(orderItem.createdAt);
     let title = orderItem?.products[0]?.name;
-    if (title?.length > maxTitleLength) {
-      if (orderItem.products.length === 1) {
-        title = truncateString({ fullString: orderItem.products[0].name, maxLength: maxTitleLength });
-      } else {
-        title = `${truncateString({ fullString: orderItem.products[0].name, maxLength: maxTitleLength })} 외 ${
-          orderItem.products.length - 1
-        } 개`;
-      }
+    if (orderItem?.products[0]?.name?.length > maxTitleLength) {
+      title = truncateString({ fullString: orderItem.products[0].name, maxLength: maxTitleLength });
+    }
+
+    if (orderItem.products.length !== 1) {
+      title += ` 외 ${orderItem.products.length - 1} 건`;
     }
 
     const ShippingCode = orderItem.state || orderItem?.products[0]?.state;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/chore-bugs -> dev

## 🔧 작업 내용
- 마이페이지 > 오늘의 추천차 버튼 클릭 시 상세페이지로 이동
마이페이지 > 상단 대시보드의 오늘의 추천차 버튼 클릭 시 상세페이지로 이동하도록 추가하였습니다.
-  footer margin 추가
- 주문 상세페이지 > 화면 깨지는 현상을 위해 min-width 설정
- 주문 상세페이지 > 리뷰하기 버튼 삭제
- 주문 상세페이지 > 주문 취소 후 상품 이미지 색 조정
- 주문 상세페이지 > 주문번호 대신 user의 id가 표시되는 버그를 수정
- 주문 내역페이지 > 주문내역에 주문 상품이 여러개인 경우 `...외 N개`와 같은 표시가 안되는 버그 수정
- 헤더에 검색 마크업 제거



## 📸 스크린샷

## 🔗 관련 이슈
#416 #412 #411 #399 #390 #377 #376 #375 #364

## 💬 참고사항
