### PR TITLE
fix(cart): 바로구매시 장바구니상품 반영 버그 해결(#418)

### DIFF
--- a/src/pages/OrderCheckoutPage.tsx
+++ b/src/pages/OrderCheckoutPage.tsx
@@ -1,6 +1,6 @@
 import { styled } from "styled-components";
 import { useEffect, useState } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useLocation, useNavigate } from "react-router-dom";
 import { AxiosError } from "axios";
 import OrderInfoContainer from "@/containers/orderCheckout/OrderInfoContainer";
@@ -17,7 +17,7 @@ import ordersApi from "@/apis/services/orders";
 const OrderCheckoutPage = () => {
   const user = useRecoilValue(loggedInUserState);
   const checkedItems = useRecoilValue(cartCheckedItemState);
-  const [cartStorage, setCartStorage] = useRecoilState(cartState);
+  const setCartStorage = useSetRecoilState(cartState);
   const [cartData, setCartData] = useState<CartItem[]>();
   const [shippingInfo, setShippingInfo] = useState<ShippingInfoType>();
   const [isStockModalOpen, setIsStockModalOpen] = useState(false);
@@ -95,7 +95,7 @@ const OrderCheckoutPage = () => {
       return { _id: item.product._id, quantity: item.quantity };
     });
     const data = {
-      products: productsData,
+      products: location.state ? [{ _id: location.state._id, quantity: location.state.quantityInput }] : productsData,
       shippingInfo: shippingInfo,
     };
     createOrder(data);


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart-> dev

## 🔧 작업 내용
- 바로구매 버튼으로 상품 구매시 장바구니 상품이 전부 구매되는 버그를 해결했습니다.
- location.state 존재 여부에 따라 주문하는 데이터를 다르게 처리했습니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
