### PR TITLE
fix(ProductList): 상품 value 불러오는 에러 수정(#421)

### DIFF
--- a/src/components/product/productlist/ProductItem.tsx
+++ b/src/components/product/productlist/ProductItem.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { useEffect } from "react";
 import ProductItemLabel from "./ProductItemLabel";
 import { Product } from "@/types/products";
 import { flattenCodeState } from "@/recoil/atoms/codeState";
@@ -13,12 +12,9 @@ interface ProductItemProps {
 const ProductItem = ({ product }: ProductItemProps) => {
   const navigate = useNavigate();
   const flattenCodes = useRecoilValue(flattenCodeState);
-  const teaTypeCode = product.extra.teaType.toString();
+  const teaTypeCode = product.extra.teaType[0];
 
   const hashTagCode = product.extra.hashTag.map((item) => `#${flattenCodes[item].value}`);
-  useEffect(() => {
-    console.log(hashTagCode);
-  }, []);
 
   return (
     <ProductItemLayer onClick={() => navigate(`/products/${product._id}`)}>
@@ -54,15 +50,17 @@ const ProductItem = ({ product }: ProductItemProps) => {
 
       <ProductItemContentWrapper>
         <ul>
-          <StyledTeaType>
-            <p>{flattenCodes[teaTypeCode].value}</p>
-          </StyledTeaType>
-          <StyledName>
-            <h3>{product.name}</h3>
-          </StyledName>
-          <StyledPrice>
-            <h2>{product.price}</h2>
-          </StyledPrice>
+          <StyledItemText>
+            <StyledTeaType>
+              <p>{flattenCodes[teaTypeCode].value}</p>
+            </StyledTeaType>
+            <StyledName>
+              <h3>{product.name}</h3>
+            </StyledName>
+            <StyledPrice>
+              <h2>{product.price}</h2>
+            </StyledPrice>
+          </StyledItemText>
 
           <StyledHashTag>
             <p>{hashTagCode}</p>
@@ -99,6 +97,10 @@ const StyledLabel = styled.ul`
 `;
 const ProductItemContentWrapper = styled.div`
   padding: 18px 14px;
+`;
+
+const StyledItemText = styled.div`
+  height: 100px;
 `;
 
 const StyledTeaType = styled.li`


### PR DESCRIPTION
## 📤 반영 브랜치
feat/main-products -> dev

## 🔧 작업 내용
productItem code 값으로 value 불러오는 코드에서 발생하는 에러를 수정하였습니다.
배열을 toString으로 변경하여 key 값으로 활용하였으나 배열 길이가 한 개 이상인 경우가 있어 에러가 발생했습니다.
해당 코드를 첫 번째 요소만 가져오는 코드로 수정하였습니다. 

## 📸 스크린샷

## 🔗 관련 이슈
#421 

## 💬 참고사항
