### PR TITLE
fix(cart): 수량자동반영시 헤더개수반영버그 해결(#413)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -44,7 +44,7 @@ const Header = () => {
   }, [user]);
 
   useEffect(() => {
-    setCartCount(cartStorage.length);
+    setCartCount(cartStorage.filter((item) => item.stock !== 0).length);
   }, [cartStorage]);
 
   const logoutHandleClick = () => {


### PR DESCRIPTION
## 📤 반영 브랜치
feat/cart -> dev

## 🔧 작업 내용
- 재고가 0개인 상품은 헤더의 개수에 반영하지 않도록 필터링했습니다.
- 카트에 머무르다가 새로고침 후 재고가 0개가 된 아이템은 개수반영에 제외합니다.

## 📸 스크린샷

## 🔗 관련 이슈

## 💬 참고사항
