### PR TITLE
fix(ProductList): 상품 아이템 하단 가려짐 이슈 해결(#429)

### DIFF
--- a/src/components/product/productlist/ProductItem.tsx
+++ b/src/components/product/productlist/ProductItem.tsx
@@ -18,7 +18,7 @@ const ProductItem = ({ product }: ProductItemProps) => {
 
   return (
     <ProductItemLayer onClick={() => navigate(`/products/${product._id}`)}>
-      <ProductItemImageWrapper $imageUrl={`${import.meta.env.VITE_API_BASE_URL}/${product.mainImages[0].url}`}>
+      <ProductItemImageWrapper>
         <StyledLabel>
           <li>
             {product.extra.isNew ? (
@@ -46,6 +46,7 @@ const ProductItem = ({ product }: ProductItemProps) => {
             )}
           </li>
         </StyledLabel>
+        <img src={`${import.meta.env.VITE_API_BASE_URL}/${product.mainImages[0].url}`} alt="" />
       </ProductItemImageWrapper>
 
       <ProductItemContentWrapper>
@@ -82,18 +83,26 @@ const ProductItemLayer = styled.div`
   cursor: pointer;
 `;
 
-const ProductItemImageWrapper = styled.div<{ $imageUrl: string }>`
-  width: 100%;
-  aspect-ratio: 1/0.7;
-  overflow: hidden;
-  background: url(${(props) => props.$imageUrl}) no-repeat;
+const ProductItemImageWrapper = styled.div`
+  position: relative;
 
-  background-size: cover;
+  width: 100%;
+  height: 240px;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
 `;
 const StyledLabel = styled.ul`
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  right: 14px;
+
   display: flex;
   justify-content: space-between;
-  padding: 12px 14px;
 `;
 const ProductItemContentWrapper = styled.div`
   padding: 18px 14px;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/main-products -> dev

## 🔧 작업 내용
상품 아이템 하단 이미지가 가려지는 이슈를 해결했습니다. 
또한 `background 속성`으로 지정돼있던 이미지를 `img 태그`로 수정하였습니다. 

## 📸 스크린샷
<img width="827" alt="이슈429 이미지" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/9daf7bf5-9c37-45cd-9277-5aa190eda811">

## 🔗 관련 이슈
#429 

## 💬 참고사항
