### PR TITLE
fix(ProductList): 상품 아이템에 단위 코드 추가(#301)

### DIFF
--- a/src/components/product/productlist/ProductItem.tsx
+++ b/src/components/product/productlist/ProductItem.tsx
@@ -5,6 +5,8 @@ import ProductItemLabel from "./ProductItemLabel";
 import { Product } from "@/types/products";
 import { flattenCodeState } from "@/recoil/atoms/codeState";
 
+import getPriceFormat from "@/utils/getPriceFormat";
+
 interface ProductItemProps {
   product: Product;
 }
@@ -15,6 +17,7 @@ const ProductItem = ({ product }: ProductItemProps) => {
   const teaTypeCode = product.extra.teaType[0];
 
   const hashTagCode = product.extra.hashTag.map((item) => `#${flattenCodes[item].value}`);
+  const priceKor = getPriceFormat({ price: product.price });
 
   return (
     <ProductItemLayer onClick={() => navigate(`/products/${product._id}`)}>
@@ -59,7 +62,7 @@ const ProductItem = ({ product }: ProductItemProps) => {
               <h3>{product.name}</h3>
             </StyledName>
             <StyledPrice>
-              <h2>{product.price}</h2>
+              <h2>{priceKor}</h2>
             </StyledPrice>
           </StyledItemText>
 


### PR DESCRIPTION
## 📤 반영 브랜치
feat/main-products -> dev

## 🔧 작업 내용
상품 아이템 가격 표시 영역에 원화 표시로 변환하는 유틸 함수 `getPriceFormat`을 사용했습니다.

## 📸 스크린샷
<img width="263" alt="이슈301 원화" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/a8ae943e-a459-405c-86d5-b0d62db7a4d0">


## 🔗 관련 이슈
#301 
## 💬 참고사항
