### PR TITLE
feat(admin): 헤더 관리자페이지 링크 라우팅 수정(#398)

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -17,6 +17,7 @@ import MyOrderDetailContainer from "./containers/mypage/MyOrderDetailContainer";
 import MyProfileLoginContainer from "./containers/mypage/MyProfileLoginContainer";
 import MyProfileEditContainer from "./containers/mypage/MyProfileModifyContainer";
 import ProtectedRoute from "./components/route/ProtectedRoute";
+import AdminPage from "./pages/AdminPage";
 
 const router = createBrowserRouter([
   {
@@ -122,11 +123,21 @@ const router = createBrowserRouter([
   },
   {
     path: "",
-    element: <ProtectedRoute location="/" modalMessage="판매 관리자만 접근 가능합니다." allowedRoles={["seller"]} />,
+    element: <ProtectedRoute location="/" modalMessage="판매 회원만 접근 가능합니다." allowedRoles={["seller"]} />,
     children: [
       {
         path: "seller/*",
         element: <SellerPage />,
+      },
+    ],
+  },
+  {
+    path: "",
+    element: <ProtectedRoute location="/" modalMessage="관리자만 접근 가능합니다." allowedRoles={["admin"]} />,
+    children: [
+      {
+        path: "admin/*",
+        element: <AdminPage />,
       },
     ],
   },

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,14 +10,14 @@ import CartPage from "@/pages/CartPage";
 import OrderCheckoutPage from "@/pages/OrderCheckoutPage";
 import OrderCompletePage from "@/pages/OrderCompletePage";
 import SellerPage from "@/pages/SellerPage";
+import MyPage from "@/pages/Mypage";
+import AdminPage from "@/pages/AdminPage";
 
-import MyPage from "./pages/Mypage";
 import MyOrderListContainer from "./containers/mypage/MyOrderListContainer";
 import MyOrderDetailContainer from "./containers/mypage/MyOrderDetailContainer";
 import MyProfileLoginContainer from "./containers/mypage/MyProfileLoginContainer";
 import MyProfileEditContainer from "./containers/mypage/MyProfileModifyContainer";
 import ProtectedRoute from "./components/route/ProtectedRoute";
-import AdminPage from "./pages/AdminPage";
 
 const router = createBrowserRouter([
   {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -123,7 +123,9 @@ const Header = () => {
           {userType === "admin" || userType === "seller" ? (
             <>
               <span style={{ color: "var(--color-gray-200)" }}>|</span>
-              <Link to={`/${userType}`}>{userType === "admin" ? "서비스관리" : "판매관리"}</Link>
+              <Link to={`/${userType}`} target="_blank">
+                {userType === "admin" ? "서비스관리" : "판매관리"}
+              </Link>
             </>
           ) : null}
         </CategoryWrapper>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -11,16 +11,13 @@ import { getProductCategoryCodeByValue } from "@/recoil/selectors/codeSelector";
 
 // constants
 import { AUTH_TOKEN_KEY } from "@/constants/api";
-import { MANAGE_TYPE } from "@/constants/user";
 
 interface CategoryLinkProps {
   $isActive?: boolean;
-  key: string;
 }
 
 const Header = () => {
   const [cartCount, setCartCount] = useState(0);
-  const [isManager, setIsManager] = useState(false);
   const [isLogin, setIsLogin] = useState(false);
   const [searchParams] = useSearchParams();
   const userType = useRecoilValue(getUserTypeState);
@@ -35,9 +32,6 @@ const Header = () => {
     const authToken = localStorage.getItem(AUTH_TOKEN_KEY);
     if (authToken) {
       setIsLogin(true);
-      if (MANAGE_TYPE.some((manageType) => userType === manageType)) {
-        setIsManager(true);
-      }
     } else {
       setIsLogin(false);
     }
@@ -51,7 +45,6 @@ const Header = () => {
     localStorage.removeItem("cartChecked");
     localStorage.removeItem("token");
     localStorage.removeItem("refreshToken");
-    setIsManager(false);
     setCartCount(0);
     setIsLogin(false);
     setUser(null);
@@ -94,9 +87,6 @@ const Header = () => {
         categoryParams: categoryCode["음료/원액"],
       },
     ],
-    admin: [
-      { name: "관리자페이지", router: "/manage", isPublic: false, location: "/manage" }, // TODO: api 개발 완료 후 라우터 수정
-    ],
   };
   const userControlList = {
     isLogin: [
@@ -130,20 +120,12 @@ const Header = () => {
               </ProductCategoryLink>
             ))}
           </div>
-          {isManager && (
-            <AdminCategoryStyle>
-              {categoryList.admin.map((category) => (
-                <AdminCategoryLink
-                  key={`${category.name}AdminCategoryLink`}
-                  $isActive={location.pathname === category.location}
-                >
-                  <Link key={`${category.name}Link`} to={category.router}>
-                    {category.name}
-                  </Link>
-                </AdminCategoryLink>
-              ))}
-            </AdminCategoryStyle>
-          )}
+          {userType === "admin" || userType === "seller" ? (
+            <>
+              <span style={{ color: "var(--color-gray-200)" }}>|</span>
+              <Link to={`/${userType}`}>{userType === "admin" ? "서비스관리" : "판매관리"}</Link>
+            </>
+          ) : null}
         </CategoryWrapper>
         {/* <SearchWrapper>
           <IconSearchCart />
@@ -176,10 +158,6 @@ const Header = () => {
 };
 
 const ProductCategoryLink = styled.span<CategoryLinkProps>`
-  color: ${({ $isActive }) => ($isActive ? "var(--color-main)" : "inherit")};
-`;
-
-const AdminCategoryLink = styled.span<CategoryLinkProps>`
   color: ${({ $isActive }) => ($isActive ? "var(--color-main)" : "inherit")};
 `;
 
@@ -221,13 +199,6 @@ const CategoryWrapper = styled.div`
     cursor: pointer;
     color: var(--color-main);
   }
-`;
-
-const AdminCategoryStyle = styled.div`
-  display: flex;
-  align-items: center;
-  height: 1.5rem;
-  border-left: 2px solid var(--color-gray-500);
 `;
 
 // 검색 기능

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,0 +1,5 @@
+const AdminPage = () => {
+  return <div></div>;
+};
+
+export default AdminPage;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/admin -> dev

## 🔧 작업 내용
- AdminPage 라우팅 설정
- userType 별 헤더 링크 url 반영
- 새탭에서 열리도록 설정

## 📸 스크린샷
<img width="596" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/fdcb6501-fd5f-4a30-b24f-491a98f234b8">

<img width="596" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/decca34f-ef8c-4c35-8c8c-de5a94b1bf21">

## 🔗 관련 이슈

## 💬 참고사항
