### PR TITLE
feat(상품상세): 메인이미지및 상세정보 출력(#441)

### DIFF
--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -163,7 +163,14 @@ const ProductDetailPage = () => {
           <Button value="구매하기" size="sm" variant="point" />
         </ButtonWrapper>
       </Modal>
-      <ProductDetailLeft>[상품 정보]상품id : {id}</ProductDetailLeft>
+      <ProductDetailLeft>
+        <img
+          src={`${import.meta.env.VITE_API_BASE_URL}${itemData?.mainImages[0].url}`}
+          alt={itemData?.name}
+          width={600}
+        />
+        <DetailArea dangerouslySetInnerHTML={{ __html: itemData?.content as TrustedHTML }}></DetailArea>
+      </ProductDetailLeft>
       <ProductDetailRight>
         <TeaType>{itemData?.extra.teaType[0] ? categoryCodes[itemData?.extra.teaType[0]].value : ""}</TeaType>
         <Title>{itemData?.name}</Title>
@@ -227,15 +234,24 @@ const ButtonWrapper = styled.div`
 `;
 
 const ProductDetailLeft = styled.section`
-  flex: 1;
-  border: 1px solid var(--color-gray-100);
+  min-width: 650px;
+  text-align: center;
+`;
+
+const DetailArea = styled.div`
+  max-width: 650px;
+  text-align: center;
+
+  & img {
+    width: 600px;
+    border: 1px solid var(--color-gray-100);
+  }
 `;
 
 const ProductDetailRight = styled.section`
-  min-width: 500px;
+  flex: 1;
   display: flex;
   flex-direction: column;
-  margin-left: 20px;
 `;
 
 const TeaType = styled.p`


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-detail -> dev

## 🔧 작업 내용
- 상품 메인 이미지와 상품상세정보 content를 출력합니다.

## 📸 스크린샷
<img width="1191" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/0d25d44c-b1e2-4d98-aba2-4ed200a64c79">

## 🔗 관련 이슈

## 💬 참고사항
content 이미지 출력이 안되거나 누락된 아이템이 있습니다.