### PR TITLE
bug(orderCheckout): 구매하기페이지 배송정보 검증 추가(#382)

### DIFF
--- a/src/containers/mypage/MyProfileModifyContainer.tsx
+++ b/src/containers/mypage/MyProfileModifyContainer.tsx
@@ -269,7 +269,7 @@ const MyProfileEditContainer = () => {
       validationMessage: validationMessage.phoneNumber,
       inputProps: {
         type: "tel",
-        maxLength: 13,
+        maxLength: 17,
         name: "phoneNumber",
         placeholder: "숫자만 입력해주세요.",
         onChange: inputHandleChange,

--- a/src/containers/orderCheckout/ShippingInfoContainer.tsx
+++ b/src/containers/orderCheckout/ShippingInfoContainer.tsx
@@ -56,6 +56,7 @@ const ShippingInfoContainer = ({ setShippingInfo }: ShippingInfoContainerProps) 
       <FormInput title="연락처">
         <Input
           type="tel"
+          maxLength={17}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange(event, setPhone)}
           value={autoHyphenPhoneNumber(phone)}
           placeholder="전화번호를 입력해주세요."
@@ -65,6 +66,7 @@ const ShippingInfoContainer = ({ setShippingInfo }: ShippingInfoContainerProps) 
       </FormInput>
       <FormInput title="주소" $marginBottom="4px">
         <Input
+          disabled
           type="text"
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange(event, setAddress)}
           value={address}

--- a/src/containers/signUp/SignUpContainer.tsx
+++ b/src/containers/signUp/SignUpContainer.tsx
@@ -297,7 +297,7 @@ const SignUpContainer = () => {
       validationMessage: validationMessage.phoneNumber,
       inputProps: {
         type: "tel",
-        maxLength: 13,
+        maxLength: 17,
         name: "phoneNumber",
         placeholder: "숫자만 입력해주세요.",
         onChange: inputHandleChange,


### PR DESCRIPTION
## 📤 반영 브랜치
feat/order-checkout-shipping-> dev

## 🔧 작업 내용
- 구매하기 페이지에서 배송 주소는 주소 api로 추가할 수 있도록 하였습니다.
- 전화번호 입력 input  관련 코드에서 ITU 권고 원칙인 (전화번호 최대 길이: 15) + (하이픈 :2개)를 더한 17글자로 수정하였습니다.

## 📸 스크린샷

## 🔗 관련 이슈
#382

## 💬 참고사항
