### PR TITLE
feat(ErrorPage): 에러페이지 디자인 및 구현(#286)

### DIFF
--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,5 +1,43 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import Button from "@/components/common/Button";
+
 const ErrorPage = () => {
-  return <div>에러페이지</div>;
+  return (
+    <ErrorPageLayer>
+      <img src="/images/emptyTea.png" alt="" />
+      <h2>찾으시는 페이지가 없습니다.</h2>
+      <p>
+        요청하신 주소를 찾을 수 없습니다. <br />
+        다시 한번 확인해 주시기 바랍니다.
+      </p>
+      <Link to="/">
+        <Button size="md" variant="point" value="홈으로 돌아가기"></Button>
+      </Link>
+    </ErrorPageLayer>
+  );
 };
 
 export default ErrorPage;
+
+const ErrorPageLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  margin-top: 120px;
+
+  h2 {
+    font-size: 2.8rem;
+    color: var(--color-gray-300);
+
+    margin-top: 18px;
+  }
+  p {
+    font-size: 1.8rem;
+    color: var(--color-gray-200);
+    line-height: 2.8rem;
+
+    margin: 14px 0 30px 0;
+  }
+`;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/main-products -> dev

## 🔧 작업 내용
애러페이지를 구현했습니다. 잘못된 경로에 들어올 경우 띄워지는 화면으로 `홈으로 돌아가기` 버튼을 넣었습니다. 

## 📸 스크린샷
<img width="1343" alt="에러 페이지" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/ce89aec0-8c22-4521-9185-6256a70eb55c">


## 🔗 관련 이슈
#286 

## 💬 참고사항
상하 중앙 정렬 이슈
