### PR TITLE
refactor(ProductList): 상품목록페이지 react-query 도입(#515)

### DIFF
--- a/src/containers/product/ProductSortContainer.tsx
+++ b/src/containers/product/ProductSortContainer.tsx
@@ -1,14 +1,11 @@
-import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import styled from "styled-components";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import productsApi, { FilterQueryObject, SortQueryObject } from "@/apis/services/products";
 import ProductItemList from "@/components/product/productlist/ProductItemList";
 import ProductSortButtons from "@/components/product/productlist/ProductSortButtons";
-import { Product } from "@/types/products";
 
 const ProductSortContainer = () => {
-  const [products, setProducts] = useState<Product[]>([]);
-
   const location = useLocation();
   const queryString = location.search;
 
@@ -53,22 +50,19 @@ const ProductSortContainer = () => {
     sortObject.price = -1;
   }
 
-  const getFilteredData = async (sortDataObject?: sortObjectType, filterDataObject?: filterObjectType) => {
-    try {
-      const response = await productsApi.searchProducts({
-        sort: sortDataObject,
-        filter: filterDataObject,
-      });
-      const { item } = response.data;
-      setProducts(item);
-    } catch (error) {
-      console.error(error);
-    }
-  };
+  const { data, error } = useSuspenseQuery({
+    queryKey: ["products", sortObject, filterObject],
+    queryFn: () =>
+      productsApi.searchProducts({
+        sort: sortObject,
+        filter: filterObject,
+      }),
+    staleTime: 1000 * 10,
+    select: (response) => response.data.item,
+    refetchOnWindowFocus: "always",
+  });
 
-  useEffect(() => {
-    getFilteredData(sortObject, filterObject);
-  }, [queryString]);
+  const products = data;
 
   return (
     <ProductSortContainerLayer>


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
상품목록페이지 api 요청 함수를 react-query를 사용해 변경하였습니다.
staleTime을 10분으로 설정하여 동일한 필터링에 대한 데이터 요청을 줄여 성능을 개선하였습니다. 

## 📸 스크린샷
https://github.com/Eurachacha/hanmogeum/assets/117130358/c553450b-ca27-47ae-8235-b240b4e06eab

## 🔗 관련 이슈
#515 

## 💬 참고사항
사용하지 않는 error 제거