### PR TITLE
feat(token): 토큰 리프레시 요청 실패시 로그아웃 처리(#462)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,12 +13,15 @@ import Header from "@/components/common/Header";
 import Footer from "@/components/common/Footer";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import ScrollTop from "./components/common/ScrollTop";
+import useAxiosInterceptor from "./hooks/useAxiosInterceptor";
+import TokenExpireModal from "./components/common/TokenExpireModal";
 
 const queryClient = new QueryClient();
 
 const App = () => {
   const setFlattenCodeState = useSetRecoilState(flattenCodeState);
   const setNestedCodeState = useSetRecoilState(nestedCodeState);
+  useAxiosInterceptor();
 
   // API를 요청하여 Code를 Set해오는 함수
   const getCodeData = async () => {
@@ -43,6 +46,7 @@ const App = () => {
         <ContentsWrapper>
           <QueryClientProvider client={queryClient}>
             <Suspense fallback={<LoadingSpinner />}>
+              <TokenExpireModal />
               <Outlet />
             </Suspense>
             <ReactQueryDevtools initialIsOpen={false} />

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,5 +1,4 @@
-import axios, { AxiosError } from "axios";
-import { AUTH_TOKEN_KEY } from "@/constants/api";
+import axios from "axios";
 
 export const publicInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -27,81 +26,3 @@ export const fileUploadInstance = axios.create({
   },
   withCredentials: true,
 });
-
-// privateInstance 요청 인터셉터(헤더에 토큰 전달)
-privateInstance.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem(AUTH_TOKEN_KEY);
-    const newConfig = { ...config };
-    if (token) {
-      newConfig.headers.Authorization = `Bearer ${token}`;
-    }
-    return newConfig;
-  },
-  (error) => {
-    return Promise.reject(error);
-  },
-);
-
-const getNewToken = async () => {
-  try {
-    const refreshToken = localStorage.getItem("refreshToken");
-
-    const response = await axios.get<{ ok: number; accessToken: string }>(
-      `${import.meta.env.VITE_API_BASE_URL}/users/refresh`,
-      {
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${refreshToken}`,
-        },
-        withCredentials: true,
-      },
-    );
-    const { accessToken: newAccessToken } = response.data;
-    return newAccessToken;
-  } catch (error) {
-    return console.error(error);
-  }
-};
-
-// privateInstance 응답 인터셉터
-privateInstance.interceptors.response.use(
-  (response) => {
-    if (response.config.url?.startsWith("/admin") || response.config.url?.startsWith("/seller")) {
-      const data = response?.data?.item;
-      if (data) {
-        if (Array.isArray(data)) {
-          const items = response?.data?.item.map((e: any) => {
-            return { ...e, id: e._id };
-          });
-          response.data.item = items;
-        } else response.data.item = { ...data, id: data._id };
-      } else {
-        response.data.item = { ...response.data.updated, id: response.data.updated?._id } || {
-            ...response.data.message,
-          } || { ...response.data.ok };
-      }
-    }
-    return response;
-  },
-  async (error: AxiosError<{ errorName: string; message: string; ok: number }>) => {
-    if (error.response?.data.errorName === "TokenExpiredError") {
-      const newAccessToken = await getNewToken();
-      if (newAccessToken) {
-        localStorage.setItem("token", newAccessToken);
-        window.location.reload();
-      }
-    }
-    return Promise.reject(error);
-  },
-);
-
-// publicInstance 응답 인터셉터
-publicInstance.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  (error) => {
-    return Promise.reject(error);
-  },
-);

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -55,7 +55,7 @@ const SpinnerWrapper = styled.div`
   justify-content: center;
   width: 100%;
   height: 100%;
-  z-index: 2000;
+  /* z-index: 2000; */
   & > div {
     margin-top: 20rem;
   }

--- a/src/components/common/TokenExpireModal.tsx
+++ b/src/components/common/TokenExpireModal.tsx
@@ -1,0 +1,23 @@
+import { useRecoilState } from "recoil";
+import Modal from "./Modal";
+import tokenExpireModalState from "@/recoil/atoms/tokenExpireModalState";
+import Button from "./Button";
+
+const TokenExpireModal = () => {
+  const [isTokenExpireModalOpen, setIsTokenExpireModalOpen] = useRecoilState(tokenExpireModalState);
+
+  const handleModal = () => {
+    setIsTokenExpireModalOpen(false);
+    window.location.assign("/login");
+  };
+
+  return (
+    <div style={{ zIndex: 99999 }}>
+      <Modal isOpen={isTokenExpireModalOpen} message="토큰이 만료되었습니다.\n로그인 페이지로 이동합니다.">
+        <Button value="확인" size="sm" variant="sub" onClick={handleModal} />
+      </Modal>
+    </div>
+  );
+};
+
+export default TokenExpireModal;

--- a/src/hooks/useAxiosInterceptor.ts
+++ b/src/hooks/useAxiosInterceptor.ts
@@ -1,0 +1,94 @@
+import axios, { AxiosError } from "axios";
+import { useSetRecoilState } from "recoil";
+import { privateInstance, publicInstance } from "@/apis/instance";
+import { AUTH_TOKEN_KEY } from "@/constants/api";
+import tokenExpireModalState from "@/recoil/atoms/tokenExpireModalState";
+
+const useAxiosInterceptor = () => {
+  const setIsTokenExpireModalOpen = useSetRecoilState(tokenExpireModalState);
+
+  // privateInstance 요청 인터셉터(헤더에 토큰 전달)
+  privateInstance.interceptors.request.use(
+    (config) => {
+      const token = localStorage.getItem(AUTH_TOKEN_KEY);
+      const newConfig = { ...config };
+      if (token) {
+        newConfig.headers.Authorization = `Bearer ${token}`;
+      }
+      return newConfig;
+    },
+    (error) => {
+      return Promise.reject(error);
+    },
+  );
+
+  const getNewToken = async () => {
+    try {
+      const refreshToken = localStorage.getItem("refreshToken");
+
+      const response = await axios.get<{ ok: number; accessToken: string }>(
+        `${import.meta.env.VITE_API_BASE_URL}/users/refresh`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${refreshToken}`,
+          },
+          withCredentials: true,
+        },
+      );
+
+      const { accessToken: newAccessToken } = response.data;
+      return newAccessToken;
+    } catch (error) {
+      // alert("토큰이 만료되었습니다. 다시 로그인해주세요.");
+      localStorage.clear();
+      setIsTokenExpireModalOpen(true);
+      // window.location.assign("/login");
+      return console.error(error);
+    }
+  };
+
+  // privateInstance 응답 인터셉터
+  privateInstance.interceptors.response.use(
+    (response) => {
+      if (response.config.url?.startsWith("/admin") || response.config.url?.startsWith("/seller")) {
+        const data = response?.data?.item;
+        if (data) {
+          if (Array.isArray(data)) {
+            const items = response?.data?.item.map((e: any) => {
+              return { ...e, id: e._id };
+            });
+            response.data.item = items;
+          } else response.data.item = { ...data, id: data._id };
+        } else {
+          response.data.item = { ...response.data.updated, id: response.data.updated?._id } || {
+              ...response.data.message,
+            } || { ...response.data.ok };
+        }
+      }
+      return response;
+    },
+    async (error: AxiosError<{ errorName: string; message: string; ok: number }>) => {
+      if (error.response?.data.errorName === "TokenExpiredError") {
+        const newAccessToken = await getNewToken();
+        if (newAccessToken) {
+          localStorage.setItem("token", newAccessToken);
+          window.location.reload();
+        }
+      }
+      return Promise.reject(error);
+    },
+  );
+
+  // publicInstance 응답 인터셉터
+  publicInstance.interceptors.response.use(
+    (response) => {
+      return response;
+    },
+    (error) => {
+      return Promise.reject(error);
+    },
+  );
+};
+
+export default useAxiosInterceptor;

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,4 +1,8 @@
+import useAxiosInterceptor from "@/hooks/useAxiosInterceptor";
+
 const AdminPage = () => {
+  useAxiosInterceptor();
+
   return <div></div>;
 };
 

--- a/src/pages/SellerPage.tsx
+++ b/src/pages/SellerPage.tsx
@@ -9,10 +9,13 @@ import OrderEdit from "@/components/admin/OrderEdit";
 import sellerDataProvider from "@/apis/services/admin/sellerDataProvider";
 import ProductCreate from "@/components/admin/ProductCreate";
 import ProductEdit from "@/components/admin/ProductEdit";
+import useAxiosInterceptor from "@/hooks/useAxiosInterceptor";
+import TokenExpireModal from "@/components/common/TokenExpireModal";
 
 export const SellerPage = () => {
   const setFlattenCodeState = useSetRecoilState(flattenCodeState);
   const setNestedCodeState = useSetRecoilState(nestedCodeState);
+  useAxiosInterceptor();
 
   const getCodeData = async () => {
     try {
@@ -29,10 +32,13 @@ export const SellerPage = () => {
   }, []);
 
   return (
-    <Admin basename="/seller" dataProvider={sellerDataProvider}>
-      <Resource name="orders" list={OrderList} edit={OrderEdit} />
-      <Resource name="products" list={ProductList} edit={ProductEdit} create={ProductCreate} />
-    </Admin>
+    <>
+      <TokenExpireModal />
+      <Admin basename="/seller" dataProvider={sellerDataProvider}>
+        <Resource name="orders" list={OrderList} edit={OrderEdit} />
+        <Resource name="products" list={ProductList} edit={ProductEdit} create={ProductCreate} />
+      </Admin>
+    </>
   );
 };
 export default SellerPage;

--- a/src/recoil/atoms/tokenExpireModalState.ts
+++ b/src/recoil/atoms/tokenExpireModalState.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const tokenExpireModalState = atom<boolean>({
+  key: "tokenExpireModalState",
+  default: false,
+});
+
+export default tokenExpireModalState;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/token-refresh -> dev

## 🔧 작업 내용
- refresh토큰 만료 여부를 recoil에 저장
- refresh토큰 만료 안내 모달 생성
- axios 인터셉터를 훅으로 분리
- 각 레이아웃 페이지에서 모달 연결
- 로딩스피너 z-index 삭제

## 💬 참고사항
모달출력시 로딩스피너가 z-index설정으로 모달 출력에 문제가 있어 수정했습니다. @jungmyungjin 