### PR TITLE
design(seller): 타이틀 및 좌측메뉴 스타일링(#553)

### DIFF
--- a/src/components/admin/SideMenu.tsx
+++ b/src/components/admin/SideMenu.tsx
@@ -1,0 +1,9 @@
+import { Menu } from "react-admin";
+
+const SideMenu = () => (
+  <Menu>
+    <Menu.ResourceItem name="orders" />
+    <Menu.ResourceItem name="products" />
+  </Menu>
+);
+export default SideMenu;

--- a/src/pages/SellerPage.tsx
+++ b/src/pages/SellerPage.tsx
@@ -1,4 +1,4 @@
-import { Admin, Resource } from "react-admin";
+import { Admin, Layout, Resource } from "react-admin";
 import { useSetRecoilState } from "recoil";
 import { useEffect } from "react";
 import OrderList from "@/components/admin/OrderList";
@@ -11,6 +11,20 @@ import ProductCreate from "@/components/admin/ProductCreate";
 import ProductEdit from "@/components/admin/ProductEdit";
 import useAxiosInterceptor from "@/hooks/useAxiosInterceptor";
 import TokenExpireModal from "@/components/common/TokenExpireModal";
+import SideMenu from "@/components/admin/SideMenu";
+
+const AdminLayout = (props: any) => (
+  <Layout
+    menu={SideMenu}
+    {...props}
+    sx={{
+      "& .RaConfigurable-root": { fontSize: "1.6rem" },
+      "& .RaCreateButton-root": { fontSize: "1.6rem", marginTop: "10px" },
+      "& .MuiList-root *": { fontSize: "1.6rem" },
+      "& .MuiList-root .RaMenuItemLink-active": { fontWeight: "var(--weight-bold)" },
+    }}
+  />
+);
 
 export const SellerPage = () => {
   const setFlattenCodeState = useSetRecoilState(flattenCodeState);
@@ -34,9 +48,15 @@ export const SellerPage = () => {
   return (
     <>
       <TokenExpireModal />
-      <Admin basename="/seller" dataProvider={sellerDataProvider}>
-        <Resource name="orders" list={OrderList} edit={OrderEdit} />
-        <Resource name="products" list={ProductList} edit={ProductEdit} create={ProductCreate} />
+      <Admin basename="/seller" dataProvider={sellerDataProvider} layout={AdminLayout}>
+        <Resource name="orders" list={OrderList} edit={OrderEdit} options={{ label: "주문 관리" }} />
+        <Resource
+          name="products"
+          list={ProductList}
+          edit={ProductEdit}
+          create={ProductCreate}
+          options={{ label: "상품 관리" }}
+        />
       </Admin>
     </>
   );


### PR DESCRIPTION
## 📤 반영 브랜치
feat/seller -> dev

## 🔧 작업 내용
- 판매관리페이지 타이틀 및 좌측메뉴 스타일링

## 📸 스크린샷
<img width="1440" alt="image" src="https://github.com/Eurachacha/hanmogeum/assets/124250465/bef2e737-19c9-42a4-844b-0431e77baa12">
