### PR TITLE
fix(구매하기): 배송정보 validation버그 해결(#555)

### DIFF
--- a/src/containers/orderCheckout/ShippingInfoContainer.tsx
+++ b/src/containers/orderCheckout/ShippingInfoContainer.tsx
@@ -56,7 +56,7 @@ const ShippingInfoContainer = ({ setShippingInfo }: ShippingInfoContainerProps) 
       <FormInput title="연락처">
         <Input
           type="tel"
-          maxLength={17}
+          maxLength={13}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleInputChange(event, setPhone)}
           value={autoHyphenPhoneNumber(phone)}
           placeholder="전화번호를 입력해주세요."

--- a/src/pages/OrderCheckoutPage.tsx
+++ b/src/pages/OrderCheckoutPage.tsx
@@ -92,7 +92,8 @@ const OrderCheckoutPage = () => {
       !shippingInfo?.name ||
       !shippingInfo?.phone ||
       !shippingInfo?.address.value ||
-      !isValidPhoneNumber(shippingInfo?.phone || "")
+      !shippingInfo?.phone ||
+      !isValidPhoneNumber(shippingInfo?.phone.replace(/[^0-9]/g, ""))
     ) {
       setIsShippingModalOpen(true);
       return;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/order-checkout -> dev

## 🔧 작업 내용

phone 인풋에 입력 시 autoHyphen이 적용되어 state에 저장됨.
하이픈이 포함된 전화번호 문자열을 validate하기 때문에 계속해서 오류가 남.
-> phone state에서 하이픈 제거 후 validation을 돌리도록 수정했습니다.
