### PR TITLE
feat(TeaSurvey): 추천페이지 작업(#360)

### DIFF
--- a/src/components/recommend/TeaSurvey.tsx
+++ b/src/components/recommend/TeaSurvey.tsx
@@ -1,22 +1,140 @@
-import styled from "styled-components";
+import styled, { css, RuleSet } from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import Button from "../common/Button";
 
-const TeaSurvey = () => {
-  const navigate = useNavigate();
+const VARIANTS = {
+  default: css`
+    background: none;
+    color: var(--color-gray-400);
+    font-weight: var(--weight-regular);
+    border: 1px solid var(--color-gray-100);
+  `,
+  active: css`
+    background: var(--color-sub-500);
+    color: var(--color-gray-100);
+    font-weight: var(--weight-bold);
+    border: 1px solid var(--color-sub-500);
+  `,
+};
 
-  // TODO: 단계 정리
-  // 1. 선택한 버튼에 따라 localStorage에 객체를 저장한다.
-  const [pack, setpack] = useState("");
+const TeaSurvey = () => {
+  // 쿼리스트링
+  const navigate = useNavigate();
+  const [pack, setPack] = useState("");
   const [taste, setTaste] = useState("");
   const [isDecaf, setIsDecaf] = useState(false);
   const [price, setPrice] = useState(0);
 
+  // 버튼 active
+  const packData = [
+    {
+      title: "티백",
+      content: "간편하게 우리는",
+      data: "PC0101",
+    },
+    {
+      title: "잎차",
+      content: "눈이 즐거운",
+      data: "PC0102",
+    },
+    {
+      title: "분말",
+      content: "속이 든든한",
+      data: "PC0103",
+    },
+    {
+      title: "음료/원액",
+      content: "차갑게 마시기 좋은",
+      data: "PC0104",
+    },
+  ];
+
+  const tasteData = [
+    {
+      title: "달콤한",
+      data: "PC0401",
+    },
+    {
+      title: "새콤한",
+      data: "PC0402",
+    },
+    {
+      title: "씁쓸한",
+      data: "PC0403",
+    },
+    {
+      title: "고소한",
+      data: "PC0404",
+    },
+    {
+      title: "깔끔한",
+      data: "PC0405",
+    },
+  ];
+
+  const isDecafData = [
+    {
+      title: "디카페인",
+      content: "밤에 마시기 좋은",
+      data: true,
+    },
+    {
+      title: "카페인",
+      content: "기운 나는",
+      data: false,
+    },
+  ];
+
+  const priceData = [
+    {
+      title: "10000원 이하",
+      data: 10000,
+    },
+    {
+      title: "20000원 이하",
+      data: 20000,
+    },
+    {
+      title: "30000원 이하",
+      data: 30000,
+    },
+    {
+      title: "모든 가격",
+      data: 1000000,
+    },
+  ];
+
+  const [isPackClicked, setIsPackClicked] = useState<number | null>(null);
+  const [isTasteClicked, setTasteIsClicked] = useState<number | null>(null);
+  const [isDecafClicked, setIsDecafClicked] = useState<number | null>(null);
+  const [isPriceClicked, setIsPriceClicked] = useState<number | null>(null);
+
+  const onPackClick = (index: number, data: string) => {
+    setIsPackClicked(index);
+    setPack(data);
+  };
+  const onTasteClick = (index: number, data: string) => {
+    setTasteIsClicked(index);
+    setTaste(data);
+  };
+  const onIsDecafClick = (index: number, data: boolean) => {
+    setIsDecafClicked(index);
+    setIsDecaf(data);
+  };
+  const onIsPriceClick = (index: number, data: number) => {
+    setIsPriceClicked(index);
+    setPrice(data);
+  };
+
+  // 로컬스토리지 저장
   const setLocalStorage = () => {
     const surveyResult = { pack: pack, taste: taste, isDecaf: isDecaf, price: price };
     localStorage.setItem("surveyResult", JSON.stringify(surveyResult));
-    navigate("/surveyresult");
+    const surveyresult = JSON.parse(localStorage.getItem("surveyResult")!);
+    navigate(
+      `/surveyresult?pack=${surveyresult.pack}&taste=${surveyresult.taste}&isDecaf=${surveyresult.isDecaf}&price=${surveyresult.price}`,
+    );
   };
 
   return (
@@ -24,116 +142,83 @@ const TeaSurvey = () => {
       <TeaSurveyWrapper>
         <StyledTeaSurveyTitle>어떤 종류를 선호하시나요?</StyledTeaSurveyTitle>
         <TeaSurveyButtonWrapper>
-          <li>
-            <button onClick={() => setpack("PC0101")}>
-              <p>간편하게 우리는</p>
-              <h2>티백</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setpack("PC0102")}>
-              <p>눈이 즐거운</p>
-              <h2>잎차</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setpack("PC0103")}>
-              <p>속이 든든한</p>
-              <h2>분말</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setpack("PC0104")}>
-              <p>차갑게 마시기 좋은</p>
-              <h2>음료/원액</h2>
-            </button>
-          </li>
+          {packData.map((item, index) => {
+            const keyIndex = index.toString();
+            return (
+              <li key={keyIndex}>
+                <StyledTeasurveyButton
+                  onClick={() => onPackClick(index, item.data)}
+                  $variantStyle={isPackClicked === index ? VARIANTS.active : VARIANTS.default}
+                >
+                  <p>{item.content}</p>
+                  <h2>{item.title}</h2>
+                </StyledTeasurveyButton>
+              </li>
+            );
+          })}
         </TeaSurveyButtonWrapper>
       </TeaSurveyWrapper>
 
       <TeaSurveyWrapper>
         <StyledTeaSurveyTitle>어떤 맛을 선호하시나요?</StyledTeaSurveyTitle>
         <TeaSurveyButtonWrapper>
-          <li>
-            <button onClick={() => setTaste("PC0401")}>
-              <h2>달콤한</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setTaste("PC0402")}>
-              <h2>새콤한</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setTaste("PC0403")}>
-              <h2>씁쓸한</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setTaste("PC0404")}>
-              <h2>고소한</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setTaste("PC0405")}>
-              <h2>깔끔한</h2>
-            </button>
-          </li>
+          {tasteData.map((item, index) => {
+            const keyIndex = index.toString();
+            return (
+              <li key={keyIndex}>
+                <StyledTeasurveyButton
+                  onClick={() => onTasteClick(index, item.data)}
+                  $variantStyle={isTasteClicked === index ? VARIANTS.active : VARIANTS.default}
+                >
+                  {/* <StyledTeasurveyButton onClick={() => setTaste(item.data)}> */}
+                  <h2>{item.title}</h2>
+                </StyledTeasurveyButton>
+              </li>
+            );
+          })}
         </TeaSurveyButtonWrapper>
       </TeaSurveyWrapper>
 
       <TeaSurveyWrapper>
         <StyledTeaSurveyTitle>디카페인도 있어요.</StyledTeaSurveyTitle>
         <TeaSurveyButtonWrapper>
-          <li>
-            <button onClick={() => setIsDecaf(true)}>
-              <p>밤에도 부담 없는</p>
-              <h2>디카페인</h2>
-            </button>
-          </li>
+          {isDecafData.map((item, index) => {
+            const keyIndex = index.toString();
 
-          <li>
-            <button onClick={() => setIsDecaf(false)}>
-              <p>기운 나는</p>
-              <h2>카페인</h2>
-            </button>
-          </li>
+            return (
+              <li key={keyIndex}>
+                <StyledTeasurveyButton
+                  onClick={() => onIsDecafClick(index, item.data)}
+                  $variantStyle={isDecafClicked === index ? VARIANTS.active : VARIANTS.default}
+                >
+                  {/* <StyledTeasurveyButton onClick={() => setIsDecaf(item.data)}> */}
+                  <p>{item.content}</p>
+                  <h2>{item.title}</h2>
+                </StyledTeasurveyButton>
+              </li>
+            );
+          })}
         </TeaSurveyButtonWrapper>
       </TeaSurveyWrapper>
 
       <TeaSurveyWrapper>
         <StyledTeaSurveyTitle>어느 가격까지 생각하시나요?</StyledTeaSurveyTitle>
         <TeaSurveyButtonWrapper>
-          <li>
-            <button onClick={() => setPrice(100000)}>
-              <h2>10000원 이하</h2>
-            </button>
-          </li>
+          {priceData.map((item, index) => {
+            const keyIndex = index.toString();
 
-          <li>
-            <button onClick={() => setPrice(200000)}>
-              <h2>20000원 이하</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setPrice(300000)}>
-              <h2>30000원 이하</h2>
-            </button>
-          </li>
-
-          <li>
-            <button onClick={() => setPrice(1000000)}>
-              <h2>모든 가격</h2>
-            </button>
-          </li>
+            return (
+              <li key={keyIndex}>
+                <StyledTeasurveyButton
+                  onClick={() => onIsPriceClick(index, item.data)}
+                  $variantStyle={isPriceClicked === index ? VARIANTS.active : VARIANTS.default}
+                >
+                  {/* <StyledTeasurveyButton onClick={() => setPrice(Number(item.data))}> */}
+                  <h2>{item.title}</h2>
+                </StyledTeasurveyButton>
+              </li>
+            );
+          })}
         </TeaSurveyButtonWrapper>
       </TeaSurveyWrapper>
 
@@ -164,18 +249,17 @@ const TeaSurveyButtonWrapper = styled.ul`
   gap: 20px;
   flex-wrap: wrap;
 
-  li button {
-    width: 100%;
-    padding: 60px 0;
-
-    background: none;
-    border: 1px solid var(--color-sub-500);
-    border-radius: 4px;
-
-    cursor: pointer;
-  }
   li button h2 {
     font-size: 1.8rem;
     margin-top: 4px;
   }
+`;
+
+const StyledTeasurveyButton = styled.button<{ $variantStyle: RuleSet<object> }>`
+  ${(props) => props.$variantStyle}
+
+  width: 100%;
+  padding: 60px 0;
+  border-radius: 4px;
+  cursor: pointer;
 `;

--- a/src/pages/TeaSurveyResultPage.tsx
+++ b/src/pages/TeaSurveyResultPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import ProductItemList from "../components/product/productlist/ProductItemList";
 import productsApi from "@/apis/services/products";
@@ -7,6 +7,18 @@ import { Extra, Product } from "@/types/products";
 import Button from "@/components/common/Button";
 
 const TeaSurveyResultPage = () => {
+  const location = useLocation();
+  const queryString = location.search;
+
+  const handleCopyClipBoard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      alert("클립보드에 링크가 복사되었습니다.");
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   const [products, setProducts] = useState<Product[]>([]);
   const localData = JSON.parse(localStorage.getItem("surveyResult") || "");
   const navigate = useNavigate();
@@ -55,6 +67,12 @@ const TeaSurveyResultPage = () => {
       <ProductItemList products={products} listCount={2} />
       <StyledTeaSurveyResultButtons>
         <Button onClick={reSurvey} size="md" value="다시 검사하기" variant="sub" />
+        <Button
+          value="링크 공유하기"
+          size="md"
+          variant="point"
+          onClick={() => handleCopyClipBoard(`${import.meta.env.VITE_API_BASE_URL}/${queryString}`)}
+        />
       </StyledTeaSurveyResultButtons>
     </TeaSurveyResultPageLayer>
   );


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
메인에서 배너를 클릭하면 나오는 차 추천페이지를 작업하였습니다.
- 클릭 시 버튼 활성화
- 결과보기 버튼 클릭 시 해당하는 제품 필터링되어 출력
- 배포 주소 바탕으로 링크 복사
- 다시 결과보기 클릭 시 설문 페이지로 이동

## 📸 스크린샷
https://github.com/Eurachacha/hanmogeum/assets/117130358/c458ec96-8fbd-4471-848e-4760198b4253

## 🔗 관련 이슈
#315 

## 💬 참고사항
모든 버튼을 클릭해야 설문 결과가 나오도록 하는 코드 추가