### PR TITLE
Feat/product lists

### DIFF
--- a/src/components/recommend/ScrollProgressbar.tsx
+++ b/src/components/recommend/ScrollProgressbar.tsx
@@ -56,6 +56,10 @@ const ScrollProgressbarLayer = styled.div`
 const ScrollProgressbarContentWrapper = styled.div`
   width: 40vw;
   margin: 0 auto;
+
+  @media (max-width: 768px) {
+    width: 80vw;
+  }
 `;
 
 const StyledScrollProgressbar = styled.div`

--- a/src/components/recommend/TeaSurvey.tsx
+++ b/src/components/recommend/TeaSurvey.tsx
@@ -253,6 +253,9 @@ const TeaSurveyButtonWrapper = styled.ul`
     font-size: 1.8rem;
     margin-top: 4px;
   }
+  @media (max-width: 768px) {
+    gap: 14px;
+  }
 `;
 
 const StyledTeasurveyButton = styled.button<{ $variantStyle: RuleSet<object> }>`
@@ -262,4 +265,8 @@ const StyledTeasurveyButton = styled.button<{ $variantStyle: RuleSet<object> }>`
   padding: 60px 0;
   border-radius: 4px;
   cursor: pointer;
+
+  @media (max-width: 768px) {
+    padding: 40px 0;
+  }
 `;

--- a/src/pages/RecommendPage.tsx
+++ b/src/pages/RecommendPage.tsx
@@ -17,4 +17,8 @@ const RecommendPageLayer = styled.div`
   width: 40vw;
   margin: 0 auto;
   background-color: #fff;
+
+  @media (max-width: 768px) {
+    width: 80vw;
+  }
 `;

--- a/src/pages/TeaSurveyResultPage.tsx
+++ b/src/pages/TeaSurveyResultPage.tsx
@@ -99,4 +99,12 @@ const StyledTeaSurveyResultButtons = styled.div`
 
   display: flex;
   gap: 20px;
+
+  @media (max-width: 768px) {
+    display: block;
+
+    button:first-child {
+      margin-bottom: 10px;
+    }
+  }
 `;


### PR DESCRIPTION
## 📤 반영 브랜치
feat/product-lists -> dev

## 🔧 작업 내용
[설문 페이지]
- viewport를 40vw에서 80vw로 변경하였습니다. 
- 상단 프로그래스바의 viewport를 40vw에서 80vw로 변경하였습니다. 

[설문 결과 페이지]
- 나란히 있던 '다시 검사하기'와 '링크 공유하기' 버튼은 화면이 줄어들었을 때 display: block 설정으로 변경하였습니다. 

## 📸 스크린샷
아이폰 SE 기준 스크린샷입니다. 
<img width="323" alt="반응형 설문" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/8326a14b-300f-4736-97cb-09e9a2361d59">
<img width="291" alt="반응형 상품결과" src="https://github.com/Eurachacha/hanmogeum/assets/117130358/cfc69c56-6684-458d-8013-f3f841168ce5">

## 🔗 관련 이슈
#571 

## 💬 참고사항
- 설문 결과 페이지 vw 또한 변경합니다. 
