### PR TITLE
feat(ProductList): 상품 목록 페이지네이션 적용(#344)

### DIFF
--- a/src/apis/services/products.ts
+++ b/src/apis/services/products.ts
@@ -23,6 +23,7 @@ interface RequestSearchProducts {
   sort?: SortQueryObject;
   filter?: FilterQueryObject;
   price?: PriceObject;
+  page?: number;
 }
 
 const getSortQueryString = (sortQueryObject: SortQueryObject) => {
@@ -60,19 +61,25 @@ const getPriceString = (priceObject: PriceObject) => {
   return `maxPrice=${priceObject}`;
 };
 
+const getPage = (pageData: number) => {
+  return `&page=${pageData}&limit=6`;
+};
+
 const productsApi = {
   getAllProducts: () => publicInstance.get<ResponseProductsList>("/products"),
   getProductById: (_id: number) => publicInstance.get<ResponseProductInfo>(`/products/${_id}`),
   getProductByIsNew: () => publicInstance.get<ResponseProductsList>(`/products?custom={"extra.isNew": true}`),
   getProductByIsBest: () => publicInstance.get<ResponseProductsList>(`/products?custom={"extra.isBest": true}`),
-  searchProducts: ({ sort, filter, price }: RequestSearchProducts) => {
+
+  searchProducts: ({ sort, filter, price, page }: RequestSearchProducts) => {
     const sortQueryString = sort ? getSortQueryString(sort) : "";
     const filterQueryString = filter ? getFilterQueryString(filter) : "";
     const priceString = price ? getPriceString(price) : "";
+    const pageString = page ? getPage(page) : "";
     return publicInstance.get<ResponseProductsList>(
       `/products?${sortQueryString}${sortQueryString && filterQueryString ? "&" : ""}${filterQueryString}${
         filterQueryString && priceString ? "&" : ""
-      }${priceString}`,
+      }${priceString}${pageString}`,
     );
   },
 };

--- a/src/components/product/productlist/ProductItemList.tsx
+++ b/src/components/product/productlist/ProductItemList.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import Pagination from "@mui/material/Pagination";
 import ProductItem from "./ProductItem";
 import { Product } from "@/types/products";
 import EmptyMessage from "@/components/common/EmptyMessage";
@@ -6,17 +7,34 @@ import EmptyMessage from "@/components/common/EmptyMessage";
 interface ProductItemListProps {
   products: Product[];
   listCount: number;
+  pagination?: number;
+  onClick?: (event: React.ChangeEvent<unknown>, page: number) => void;
+  currentPage: number;
 }
 
-const ProductItemList = ({ products, listCount }: ProductItemListProps) => {
+const ProductItemList = ({ products, listCount, pagination, onClick, currentPage }: ProductItemListProps) => {
   return products.length ? (
-    <ProductItemListLayer $listCount={listCount}>
-      {products &&
-        products.map((product, idx) => {
-          const key = idx.toString();
-          return <ProductItem product={product} key={key} />;
-        })}
-    </ProductItemListLayer>
+    <>
+      <ProductItemListLayer $listCount={listCount}>
+        {products &&
+          products.map((product, idx) => {
+            const key = idx.toString();
+            return <ProductItem product={product} key={key} />;
+          })}
+      </ProductItemListLayer>
+      <PaginationWrapper>
+        <Pagination
+          defaultPage={1}
+          page={currentPage}
+          count={pagination}
+          onChange={onClick}
+          shape="rounded"
+          showFirstButton
+          showLastButton
+          size="large"
+        />
+      </PaginationWrapper>
+    </>
   ) : (
     <EmptyMessage />
   );
@@ -31,4 +49,11 @@ const ProductItemListLayer = styled.div<{ $listCount: number }>`
   @media (max-width: 768px) {
     grid-template-columns: repeat(${(props) => props.$listCount - 1}, 1fr);
   }
+`;
+
+const PaginationWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+
+  margin-top: 40px;
 `;

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -42,10 +42,17 @@ export interface ProductDetailWithReplies extends ProductDetail {
 }
 
 // Reponse Types
+export interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
 
 export interface ResponseProductsList {
   ok: number;
   item: Product[];
+  pagination: Pagination;
 }
 
 export interface ResponseProductInfo {


### PR DESCRIPTION
## 📤 반영 브랜치
feat/main-products -> dev

## 🔧 작업 내용
상품 목록 페이지에 페이지네이션을 적용하여 6개씩 보여주는 코드를 추가했습니다.

## 📸 스크린샷


## 🔗 관련 이슈
#344 

## 💬 참고사항
무한스크롤을 적용하려다 페이지네이션으로 변경하였습니다. 
